### PR TITLE
Enable cyclop,  gosec and gocritic linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,10 @@
+# golangci.com configuration
+# https://golangci-lint.run/usage/configuration/
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 15m
+
 linters:
-  # Disable all linters.
-  # Default: false
-  disable-all: true
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
@@ -11,13 +14,14 @@ linters:
     - bodyclose
     # containedctx
     # contextcheck
-    # cyclop TODO: Reduce complexity
+    - cyclop
+    # deadcode Replaced by unused.
     - depguard
     - dupword
     - durationcheck
     - errcheck
     - errchkjson
-    # errname
+    # errname TODO
     - execinquery
     # exhaustive
     # exhaustivestruct
@@ -26,27 +30,28 @@ linters:
     - forbidigo
     # forcetypeassert
     - funlen
-    # gci
+    - gci
     # gochecknoglobals
     # gochecknoinits
     - gocognit
-    # goconst
-    # gocritic
+    - goconst
+    - gocritic
     - gocyclo
-    # godot
-    # goerr113 TODO: Use errors.Is
+    - godot
+    # goerr113
     - gofmt
-    # gofumpt
     - goheader
-    - goimports
-    # gomnd TODO: Avoid magic numbers
-    - gomoddirectives
+    # goimports
+    # golint Replaced by revive.
+    # gomnd
+    # gomoddirectives replacement are not allowed: antreacloud-utils
     - gomodguard
     - goprintffuncname
-    # gosec
+    - gosec
     - gosimple
     - govet
     - grouper
+    - importas
     - ineffassign
     - lll
     - loggercheck
@@ -54,33 +59,34 @@ linters:
     - makezero
     - misspell
     - nakedret
-    # nestif TODO: Reduce complexity
+    - nestif
     - nilerr
     - nilnil
     - noctx
     - nolintlint
-    # nonamedreturns TODO: Avoid namedreturns
+    # nonamedreturns TODO
     - nosprintfhostport
     # paralleltest
     - prealloc
-    # predeclared
+    - predeclared
     - promlinter
     - reassign
     - revive
     - staticcheck
-    # stylecheck  db/Db instead of DB
+    # structcheck Replaced by unused.
+    # stylecheck
     - tagliatelle
     - tenv
     - testableexamples
     # testpackage
     # thelper
     - tparallel
-    # typecheck
+    - typecheck
     - unconvert
-    # unparam  TODO: Remove unused params
+    - unparam
     - unused
     - usestdlibvars
-    # whitespace
+    - whitespace
     # wrapcheck
     # wsl
   # Run only fast linters from enabled linters set (first run won't be fast)
@@ -88,17 +94,45 @@ linters:
   fast: false
 
 linters-settings:
+  cyclop:
+    # The maximal code complexity to report.
+    # Default: 10
+    max-complexity: 12
+    # The maximal average package complexity.
+    # If it's higher than 0.0 (float) the check is enabled
+    # Default: 0.0
+    package-average: 0.0
+    # Should ignore tests.
+    # Default: false
+    skip-tests: true
   funlen:
     lines: 120
     statements: 120
   goconst:
-    min-len: 3
-    min-occurrences: 2
+    min-len: 5
+    min-occurrences: 5
+  importas:
+    # Do not allow unaliased imports of aliased packages.
+    # Default: false
+    no-unaliased: true
+    # Do not allow non-required aliases.
+    # Default: false
+    no-extra-aliases: false
+    # List of aliases
+    # Default: []
+    alias:
+      # Using `servingv1` alias for `knative.dev/serving/pkg/apis/serving/v1` package.
+      - pkg: knative.dev/serving/pkg/apis/serving/v1
+        alias: servingv1
   lll:
     line-length: 180
     tab-width: 1
   misspell:
     locale: US
+  nestif:
+    # Minimal complexity of if statements to report.
+    # Default: 5
+    min-complexity: 8
   revive:
     ignore-generated-header: true
     severity: warning
@@ -107,9 +141,30 @@ linters-settings:
       - name: line-length-limit
         severity: error
         arguments: [330]
+  tagliatelle:
+    # Check the struct tag name case.
+    case:
+      # Use the struct field name to check the name of the struct tag.
+      # Default: false
+      use-field-name: true
+      # `camel` is used for `json` and `yaml` (can be overridden)
+      # Default: {}
+      rules:
+        # Any struct tag type can be used.
+        # Support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`
+        json: snake
+        yaml: camel
+        xml: camel
+        bson: camel
+        avro: snake
+        mapstructure: kebab
 
 issues:
   exclude-rules:
-    - linters:
+    - path: _test\.go
+      linters:
+        - cyclop
         - funlen
-      source: "^func Test"
+        - gocritic
+        - gosec
+        - unparam

--- a/build/_typos.toml
+++ b/build/_typos.toml
@@ -1,5 +1,6 @@
 [default.extend-identifiers]
 # *sigh* this just isn't worth the cost of fixing
+importas = "importas"
 
 [default.extend-words]
 # Accepted words to be ignored by typos

--- a/build/lint.sh
+++ b/build/lint.sh
@@ -5,7 +5,6 @@ set -eux
 
 $(dirname $0)/typos.sh
 $(go env GOPATH)/bin/shfmt -d -ci -i 2 .
-
-CGO_ENABLED=0 $(go env GOPATH)/bin/golangci-lint run
+$(go env GOPATH)/bin/golangci-lint run -v
 
 gomarkdoc -c -o docs/DOCUMENTATION.md github.com/vmware-labs/multi-tenant-persistence-for-saas/data-access-layer/datastore --repository.default-branch main --repository.path /

--- a/build/lint_fix.sh
+++ b/build/lint_fix.sh
@@ -4,6 +4,8 @@ set -eux
 . $(dirname "$0")/env.sh
 
 $(dirname $0)/typos.sh --fix
+$(go env GOPATH)/bin/golangci-lint run --fix -v
+$(go env GOPATH)/bin/golangci-lint run --enable-all -c /dev/null --fix || echo "Ignore failures in DISABLED linters ..."
 
 go vet ./...
 go fix ./...

--- a/data-access-layer/datastore/authorizer.go
+++ b/data-access-layer/datastore/authorizer.go
@@ -52,8 +52,7 @@ const (
 	METADATA_ROLE_AUDITOR         = "auditor" // can be tenant_auditor, *_auditor
 )
 
-type MetadataBasedAuthorizer struct {
-}
+type MetadataBasedAuthorizer struct{}
 
 func (s MetadataBasedAuthorizer) GetOrgFromContext(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
@@ -103,8 +102,9 @@ func (s MetadataBasedAuthorizer) IsOperationAllowed(ctx context.Context, tableNa
 	}
 
 	// If the DB role is tenant-specific (TENANT_READER or TENANT_WRITER) and the table is multi-tenant,
-	//make sure that the record being inserted/modified/updated/deleted/queried belongs to the user's org.
-	//If operation is SELECT but no specific tenant's data is being queried (e.g., FindAll() was called), allow the operation to proceed
+	// make sure that the record being inserted/modified/updated/deleted/queried belongs to the user's org.
+	// If operation is SELECT but no specific tenant's data is being queried (e.g., FindAll() was called),
+	// allow the operation to proceed
 	if dbRole.IsTenantDbRole() && IsMultitenant(record, tableName) {
 		orgId, err := s.GetOrgFromContext(ctx)
 		// OrgId check required for Tenant DB roles only
@@ -128,6 +128,7 @@ func (s MetadataBasedAuthorizer) Configure(_ ...interface{}) {
 func (s MetadataBasedAuthorizer) GetAuthContext(orgId string, roles ...string) context.Context {
 	return metadata.NewIncomingContext(context.Background(), metadata.Pairs(METADATA_KEY_ORGID, orgId, METADATA_KEY_ROLE, roles[0]))
 }
+
 func (s MetadataBasedAuthorizer) GetDefaultOrgAdminContext() context.Context {
 	return s.GetAuthContext(GLOBAL_DEFAULT_ORG_ID, METADATA_ROLE_ADMIN)
 }

--- a/data-access-layer/datastore/authorizer_test.go
+++ b/data-access-layer/datastore/authorizer_test.go
@@ -26,16 +26,16 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// Checks that it's possible to extract org. ID from auth. context
+// Checks that it's possible to extract org. ID from auth. context.
 func testGettingOrgFromContext(t *testing.T, authorizer Authorizer) {
 	t.Helper()
 	assert := assert.New(t)
 
-	//Negative test case - no auth. context in ctx
+	// Negative test case - no auth. context in ctx
 	_, err := authorizer.GetOrgFromContext(context.Background())
 	assert.ErrorIs(err, ErrorFetchingMetadataFromContext)
 
-	//Negative test cases - missing org. ID
+	// Negative test cases - missing org. ID
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(METADATA_KEY_ROLE, "admin"))
 	_, err = authorizer.GetOrgFromContext(ctx)
 	assert.ErrorIs(err, ErrorMissingOrgId)
@@ -50,7 +50,7 @@ func TestGettingOrgFromContextWithMetadataAuthorizer(t *testing.T) {
 	testGettingOrgFromContext(t, MetadataBasedAuthorizer{})
 }
 
-// Positive test case
+// Positive test case.
 func TestGettingMatchingDbRoleWithMetadataBasedAuthorizer(t *testing.T) {
 	assert := assert.New(t)
 
@@ -70,7 +70,7 @@ func TestGettingMatchingDbRoleWithMetadataBasedAuthorizer(t *testing.T) {
 /*
 Positive test case.
 Checks that MetadataBasedAuthorizer permits access to other tenants' data for READER & WRITER roles
-and does not permit access to other tenants' data for TENANT_READER & TENANT_WRITER roles
+and does not permit access to other tenants' data for TENANT_READER & TENANT_WRITER roles.
 */
 func TestAllowingOperationsWithMetadataBasedAuthorizer(t *testing.T) {
 	assert := assert.New(t)
@@ -81,18 +81,18 @@ func TestAllowingOperationsWithMetadataBasedAuthorizer(t *testing.T) {
 
 	someApp := app{
 		Id:    "001",
-		OrgId: COKE, //Another tenant's record
+		OrgId: COKE, // Another tenant's record
 	}
 
-	//You should not be able to access other tenants' data with TENANT_READER role
+	// You should not be able to access other tenants' data with TENANT_READER role
 	err := authorizer.IsOperationAllowed(tenantAuditorCtx, "app", someApp)
 	assert.ErrorIs(err, ErrOperationNotAllowed)
 
-	//You should be able to access other tenants' data with TENANT_WRITER role
+	// You should be able to access other tenants' data with TENANT_WRITER role
 	err = authorizer.IsOperationAllowed(serviceAdminCtx, "app", someApp)
 	assert.ErrorIs(err, ErrOperationNotAllowed)
 
-	//You should always be able to perform a SELECT operation if you're not adding a filter with another tenant's org. ID
+	// You should always be able to perform a SELECT operation if you're not adding a filter with another tenant's org. ID
 	err = authorizer.IsOperationAllowed(serviceAdminCtx, "app", app{})
 	assert.Nil(err)
 }

--- a/data-access-layer/datastore/datastore.go
+++ b/data-access-layer/datastore/datastore.go
@@ -24,7 +24,7 @@ import (
 )
 
 /*
-Datastore: Interface to be implemented by the persistence library
+Datastore: Interface to be implemented by the persistence library.
 */
 type dataStore interface {
 	GetAuthorizer() Authorizer
@@ -60,9 +60,11 @@ type DataStoreTestHelper interface {
 	Truncate(tableNames ...string) error // Truncates DB tables
 }
 
-var DataStore dataStore = &relationalDb
-var Helper DataStoreHelper = &relationalDb
-var TestHelper DataStoreTestHelper = &relationalDb
+var (
+	DataStore  dataStore           = &relationalDb
+	Helper     DataStoreHelper     = &relationalDb
+	TestHelper DataStoreTestHelper = &relationalDb
+)
 
 func configureDataStore(isDataStoreInMemory bool, authorizer Authorizer) {
 	if authorizer == nil {

--- a/data-access-layer/datastore/datastore_test.go
+++ b/data-access-layer/datastore/datastore_test.go
@@ -36,22 +36,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Organizations
-const COKE = "Coke"
-const PEPSI = "Pepsi"
+// Organizations.
+const (
+	COKE  = "Coke"
+	PEPSI = "Pepsi"
+)
 
-// Service roles for test cases
-const TENANT_AUDITOR = "tenant_auditor"
-const TENANT_ADMIN = "tenant_admin"
-const SERVICE_AUDITOR = "service_auditor"
-const SERVICE_ADMIN = "service_admin"
-const RANDOM_ID = "SomeRandomId"
+// Service roles for test cases.
+const (
+	TENANT_AUDITOR  = "tenant_auditor"
+	TENANT_ADMIN    = "tenant_admin"
+	SERVICE_AUDITOR = "service_auditor"
+	SERVICE_ADMIN   = "service_admin"
+	RANDOM_ID       = "SomeRandomId"
+)
 
-var serviceAdminCtx = DataStore.GetAuthorizer().GetAuthContext("", SERVICE_ADMIN)
-var cokeAdminCtx = DataStore.GetAuthorizer().GetAuthContext(COKE, TENANT_ADMIN)
-var cokeAuditorCtx = DataStore.GetAuthorizer().GetAuthContext(COKE, TENANT_AUDITOR)
-var pepsiAdminCtx = DataStore.GetAuthorizer().GetAuthContext(PEPSI, TENANT_ADMIN)
-var pepsiAuditorCtx = DataStore.GetAuthorizer().GetAuthContext(PEPSI, TENANT_AUDITOR)
+var (
+	serviceAdminCtx = DataStore.GetAuthorizer().GetAuthContext("", SERVICE_ADMIN)
+	cokeAdminCtx    = DataStore.GetAuthorizer().GetAuthContext(COKE, TENANT_ADMIN)
+	cokeAuditorCtx  = DataStore.GetAuthorizer().GetAuthContext(COKE, TENANT_AUDITOR)
+	pepsiAdminCtx   = DataStore.GetAuthorizer().GetAuthContext(PEPSI, TENANT_ADMIN)
+	pepsiAuditorCtx = DataStore.GetAuthorizer().GetAuthContext(PEPSI, TENANT_AUDITOR)
+)
 
 var allResources = []Record{
 	app{},
@@ -77,7 +83,7 @@ var datastoreDbTableNames = []string{
 	GetTableName(group{}),
 }
 
-//TODO - add a test that would show that the DB users are not able to create, drop, or truncate tables
+// TODO - add a test that would show that the DB users are not able to create, drop, or truncate tables
 
 type appUser struct {
 	Id             string `db_column:"app_user_id" primary_key:"true"`
@@ -90,10 +96,11 @@ type appUser struct {
 	Msg            []byte `db_column:"msg"`
 }
 
-type appUserSlice []appUser //Needed for sorting
+type appUserSlice []appUser // Needed for sorting
 func (a appUserSlice) Len() int {
 	return len(a)
 }
+
 func (a appUserSlice) Less(x, y int) bool {
 	boolToInt := func(input bool) int {
 		var output int = 0
@@ -106,11 +113,11 @@ func (a appUserSlice) Less(x, y int) bool {
 	for i := 0; i < len(a[x].GetId()); i++ {
 		first, second := a[x].GetId()[i], a[y].GetId()[i]
 		if first == second {
-			//Two columns of the composite key are equal - proceed to the next column
+			// Two columns of the composite key are equal - proceed to the next column
 			continue
 		}
 
-		//Two columns of the composite key are not equal - decide which one is smaller
+		// Two columns of the composite key are not equal - decide which one is smaller
 		switch t := first.(type) {
 		case int, int32, int64, int8, int16:
 			return first.(int64) < second.(int64)
@@ -158,10 +165,12 @@ func (a app) areNonKeyFieldsEmpty() bool {
 	return cmp.Equal(a, app{})
 }
 
-// Input for all test cases. Inserted into data store by prepareInput()
-var myCokeApp app
-var user1 appUser
-var user2 appUser
+// Input for all test cases. Inserted into data store by prepareInput().
+var (
+	myCokeApp app
+	user1     appUser
+	user2     appUser
+)
 
 /*
 Prepared input for all test cases. Stores the input in global variables.
@@ -179,8 +188,8 @@ func prepareInput() (app, appUser, appUser) {
 		Name:           "Jeyhun",
 		Email:          "jeyhun@mail.com",
 		EmailConfirmed: true,
-		NumFollowing:   2147483647,          //int32 type
-		NumFollowers:   9223372036854775807, //int64 type
+		NumFollowing:   2147483647,          // int32 type
+		NumFollowers:   9223372036854775807, // int64 type
 		AppId:          myCokeApp.Id,
 		Msg:            []byte("msg1234"),
 	}
@@ -196,15 +205,12 @@ func prepareInput() (app, appUser, appUser) {
 		Msg:            []byte("msg9876"),
 	}
 
-	//Make sure the 2 users  are sorted in ascending order by ID
+	// Make sure the 2 users  are sorted in ascending order by ID
 	if user1.Id >= user2.Id {
-		tempUser := user1
-		user1 = user2
-		user2 = tempUser
+		user1, user2 = user2, user1
 	}
 
 	return myCokeApp, user1, user2
-
 }
 
 func createDbTables(ctx context.Context) error {
@@ -227,7 +233,7 @@ func TestTruncate(t *testing.T) {
 
 	setupDbTables(t)
 
-	var queryResults = make([]app, 0)
+	queryResults := make([]app, 0)
 	if err := DataStore.FindAll(cokeAdminCtx, &queryResults); err != nil {
 		assert.FailNow(fmt.Sprintf("Failed to query DB table %s: %s", GetTableName(app{}), err.Error()))
 	} else if len(queryResults) == 0 {
@@ -289,7 +295,7 @@ func testCrud(t *testing.T, ctx context.Context) {
 
 	var err error
 
-	//Querying of previously inserted records should succeed
+	// Querying of previously inserted records should succeed
 	for _, record := range []appUser{user1, user2} {
 		var queryResult appUser = appUser{Id: record.Id}
 		err = DataStore.Find(ctx, &queryResult)
@@ -297,7 +303,7 @@ func testCrud(t *testing.T, ctx context.Context) {
 		assert.Equal(record, queryResult)
 	}
 
-	//Updating non-key fields in a record should succeed
+	// Updating non-key fields in a record should succeed
 	user1.Name = "Jeyhun G."
 	user1.Email = "jeyhun111@mail.com"
 	user1.EmailConfirmed = !user1.EmailConfirmed
@@ -316,7 +322,7 @@ func testCrud(t *testing.T, ctx context.Context) {
 		assert.Equal(record, queryResult)
 	}
 
-	//Upsert operation should be an update for already existing records
+	// Upsert operation should be an update for already existing records
 	user1.NumFollowers++
 	user2.NumFollowers--
 	for _, record := range []appUser{user1, user2} {
@@ -329,7 +335,7 @@ func testCrud(t *testing.T, ctx context.Context) {
 		assert.Equal(record, queryResult)
 	}
 
-	//Deletion of existing records should not fail, and the records should no longer be found in the DB
+	// Deletion of existing records should not fail, and the records should no longer be found in the DB
 	for _, record := range []appUser{user1, user2} {
 		rowsAffected, err := DataStore.Delete(ctx, record)
 		assert.NoError(err)
@@ -433,7 +439,7 @@ func TestCrudInMemory(t *testing.T) {
 func testFindAll(t *testing.T, ctx context.Context) {
 	assert := assert.New(t)
 
-	//FindAll should return all (two) records
+	// FindAll should return all (two) records
 	queryResults := make([]appUser, 0)
 	err := DataStore.FindAll(ctx, &queryResults)
 	sort.Sort(appUserSlice(queryResults))
@@ -452,16 +458,16 @@ func testFindWithCriteria(t *testing.T, ctx context.Context) {
 
 	expected := []appUser{user1, user2}
 
-	//Pass filtering criteria
+	// Pass filtering criteria
 	for _, user := range expected {
-		//Search by all fields
+		// Search by all fields
 		queryResults := make([]appUser, 0)
 		err := DataStore.FindWithFilter(ctx, &user, &queryResults)
 		assert.NoError(err)
 		assert.Len(queryResults, 1)
 		assert.Equal(user, queryResults[0])
 
-		//Search only by name
+		// Search only by name
 		queryResults = make([]appUser, 0)
 		err = DataStore.FindWithFilter(ctx, &appUser{Name: user.Name}, &queryResults)
 		assert.NoError(err)
@@ -490,115 +496,115 @@ func TestCrudWithMissingOrgId(t *testing.T) {
 	setupEmptyDbTables(t)
 	_, apps := make([]appUser, 0), make([]app, 0)
 
-	//Insert some data, to make sure that DAL methods fail not due to data missing in data store
+	// Insert some data, to make sure that DAL methods fail not due to data missing in data store
 	rowsAffected, err := DataStore.Insert(cokeAdminCtx, appUser{Id: RANDOM_ID})
 	assert.NoError(err)
 	assert.Equal(int64(1), rowsAffected)
 
-	//FIND ALL
-	err = DataStore.FindAll(context.Background(), &apps) //Missing org. ID in context
+	// FIND ALL
+	err = DataStore.FindAll(context.Background(), &apps) // Missing org. ID in context
 	assert.ErrorIs(err, ErrorFetchingMetadataFromContext)
 
-	//FIND BY ID
-	err = DataStore.Find(context.Background(), &app{Id: "random ID"}) //Missing org. ID in context
+	// FIND BY ID
+	err = DataStore.Find(context.Background(), &app{Id: "random ID"}) // Missing org. ID in context
 	assert.ErrorIs(err, ErrorFetchingMetadataFromContext)
 
-	//DELETE
-	_, err = DataStore.Delete(context.Background(), app{Id: "random ID"}) //Missing org. ID in context
+	// DELETE
+	_, err = DataStore.Delete(context.Background(), app{Id: "random ID"}) // Missing org. ID in context
 	assert.ErrorIs(err, ErrorFetchingMetadataFromContext)
 
-	//INSERT
-	rowsAffected, err = DataStore.Insert(context.Background(), app{Id: RANDOM_ID}) //Missing org. ID in context
+	// INSERT
+	rowsAffected, err = DataStore.Insert(context.Background(), app{Id: RANDOM_ID}) // Missing org. ID in context
 	assert.ErrorIs(err, ErrorFetchingMetadataFromContext)
 	assert.Equal(int64(0), rowsAffected)
 
-	//UPDATE
-	_, err = DataStore.Update(context.Background(), app{Id: RANDOM_ID}) //Missing org. ID in context
+	// UPDATE
+	_, err = DataStore.Update(context.Background(), app{Id: RANDOM_ID}) // Missing org. ID in context
 	assert.ErrorIs(err, ErrorFetchingMetadataFromContext)
 
 	_, err = DataStore.Delete(cokeAdminCtx, appUser{Id: RANDOM_ID})
 	assert.NoError(err)
 
-	//JOIN ONE TO MANY
+	// JOIN ONE TO MANY
 	var queryResult2 appUserSlice = make([]appUser, 1)
-	err = DataStore.PerformJoinOneToMany(context.Background(), &app{}, RANDOM_ID, "app_id", &queryResult2) //Missing org. ID
+	err = DataStore.PerformJoinOneToMany(context.Background(), &app{}, RANDOM_ID, "app_id", &queryResult2) // Missing org. ID
 	assert.ErrorIs(err, ErrorFetchingMetadataFromContext)
 
-	err = DataStore.PerformJoinOneToOne(context.Background(), &app{}, RANDOM_ID, &appUser{}, "app_id") //Missing org. ID
+	err = DataStore.PerformJoinOneToOne(context.Background(), &app{}, RANDOM_ID, &appUser{}, "app_id") // Missing org. ID
 	assert.ErrorIs(err, ErrorFetchingMetadataFromContext)
 }
 
 func testCrudWithInvalidParams(t *testing.T, ctx context.Context) {
 	assert := assert.New(t)
 
-	//Insert some data, to make sure that DAL methods fail not due to data missing in data store
+	// Insert some data, to make sure that DAL methods fail not due to data missing in data store
 	rowsAffected, err := DataStore.Insert(ctx, appUser{Id: RANDOM_ID})
 	assert.NoError(err)
 	assert.Equal(int64(1), rowsAffected)
 
-	//FIND ALL
+	// FIND ALL
 	var apps []app
-	err = DataStore.FindAll(ctx, apps) //Passing a nil slice
+	err = DataStore.FindAll(ctx, apps) // Passing a nil slice
 	assert.ErrorIs(err, IllegalArgumentError)
 
 	apps = make([]app, 0)
 
-	//FIND ALL
-	err = DataStore.FindAll(ctx, apps) //Passing slice by value
+	// FIND ALL
+	err = DataStore.FindAll(ctx, apps) // Passing slice by value
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	//FIND ALL
-	err = DataStore.FindAll(ctx, &app{}) //Passing a struct by reference (instead of a slice of structs by reference)
+	// FIND ALL
+	err = DataStore.FindAll(ctx, &app{}) // Passing a struct by reference (instead of a slice of structs by reference)
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	//FIND BY ID
-	err = DataStore.Find(ctx, appUser{}) //Passing a struct instead of a pointer to a struct
+	// FIND BY ID
+	err = DataStore.Find(ctx, appUser{}) // Passing a struct instead of a pointer to a struct
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	//JOIN ONE TO MANY
+	// JOIN ONE TO MANY
 	var queryResult2 appUserSlice = make([]appUser, 1)
-	err = DataStore.PerformJoinOneToMany(ctx, app{}, RANDOM_ID, "app_id", &queryResult2) //Passing a struct instead of a pointer to a struct
+	err = DataStore.PerformJoinOneToMany(ctx, app{}, RANDOM_ID, "app_id", &queryResult2) // Passing a struct instead of a pointer to a struct
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	err = DataStore.PerformJoinOneToMany(ctx, &app{}, "", "app_id", &queryResult2) //Passing an empty ID
+	err = DataStore.PerformJoinOneToMany(ctx, &app{}, "", "app_id", &queryResult2) // Passing an empty ID
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	err = DataStore.PerformJoinOneToMany(ctx, &app{}, "    ", "app_id", &queryResult2) //Passing a blank ID
+	err = DataStore.PerformJoinOneToMany(ctx, &app{}, "    ", "app_id", &queryResult2) // Passing a blank ID
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	err = DataStore.PerformJoinOneToMany(ctx, &app{}, RANDOM_ID, "app_id", make([]appUser, 1)) //Passing a slice instead of a pointer to a slice
+	err = DataStore.PerformJoinOneToMany(ctx, &app{}, RANDOM_ID, "app_id", make([]appUser, 1)) // Passing a slice instead of a pointer to a slice
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	err = DataStore.PerformJoinOneToMany(ctx, &app{}, RANDOM_ID, "app_id", &appUser{}) //Passing a pointer but not to a slice
+	err = DataStore.PerformJoinOneToMany(ctx, &app{}, RANDOM_ID, "app_id", &appUser{}) // Passing a pointer but not to a slice
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	err = DataStore.PerformJoinOneToMany(ctx, &app{}, RANDOM_ID, "", &queryResult2) //Passing an empty join column name
+	err = DataStore.PerformJoinOneToMany(ctx, &app{}, RANDOM_ID, "", &queryResult2) // Passing an empty join column name
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	err = DataStore.PerformJoinOneToMany(ctx, &app{}, RANDOM_ID, "    ", &queryResult2) //Passing a blank join column name
+	err = DataStore.PerformJoinOneToMany(ctx, &app{}, RANDOM_ID, "    ", &queryResult2) // Passing a blank join column name
 	assert.ErrorIs(err, IllegalArgumentError)
 
 	queryResult2 = make([]appUser, 0)
-	err = DataStore.PerformJoinOneToMany(ctx, &app{}, RANDOM_ID, "app_id", &queryResult2) //Passing an empty slice
+	err = DataStore.PerformJoinOneToMany(ctx, &app{}, RANDOM_ID, "app_id", &queryResult2) // Passing an empty slice
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	//JOIN ONE TO ONE
-	err = DataStore.PerformJoinOneToOne(ctx, app{}, RANDOM_ID, &appUser{}, "app_id") //Passing a struct instead of a pointer to a struct
+	// JOIN ONE TO ONE
+	err = DataStore.PerformJoinOneToOne(ctx, app{}, RANDOM_ID, &appUser{}, "app_id") // Passing a struct instead of a pointer to a struct
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	err = DataStore.PerformJoinOneToOne(ctx, &app{}, "", &appUser{}, "app_id") //Passing an empty ID
+	err = DataStore.PerformJoinOneToOne(ctx, &app{}, "", &appUser{}, "app_id") // Passing an empty ID
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	err = DataStore.PerformJoinOneToOne(ctx, &app{}, "    ", &appUser{}, "app_id") //Passing a blank ID
+	err = DataStore.PerformJoinOneToOne(ctx, &app{}, "    ", &appUser{}, "app_id") // Passing a blank ID
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	err = DataStore.PerformJoinOneToOne(ctx, &app{}, RANDOM_ID, appUser{}, "app_id") //Passing a struct instead of a pointer to a struct
+	err = DataStore.PerformJoinOneToOne(ctx, &app{}, RANDOM_ID, appUser{}, "app_id") // Passing a struct instead of a pointer to a struct
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	err = DataStore.PerformJoinOneToOne(ctx, &app{}, RANDOM_ID, &appUser{}, "") //Passing an empty join column name
+	err = DataStore.PerformJoinOneToOne(ctx, &app{}, RANDOM_ID, &appUser{}, "") // Passing an empty join column name
 	assert.ErrorIs(err, IllegalArgumentError)
 
-	err = DataStore.PerformJoinOneToOne(ctx, &app{}, RANDOM_ID, &appUser{}, "    ") //Passing a blank column name
+	err = DataStore.PerformJoinOneToOne(ctx, &app{}, RANDOM_ID, &appUser{}, "    ") // Passing a blank column name
 	assert.ErrorIs(err, IllegalArgumentError)
 }
 
@@ -622,7 +628,7 @@ func testJoins(t *testing.T, ctx context.Context) {
 	assert := assert.New(t)
 
 	{
-		//Perform join
+		// Perform join
 		var queryResult1 app = app{}
 		var queryResult2 appUserSlice = make([]appUser, 1)
 		err := DataStore.PerformJoinOneToMany(ctx, &queryResult1, myCokeApp.GetId()[0].(string), "app_id", &queryResult2)
@@ -631,16 +637,16 @@ func testJoins(t *testing.T, ctx context.Context) {
 
 		assert.Equal(myCokeApp, queryResult1)
 
-		//There should be 2 output records
+		// There should be 2 output records
 		assert.Len(queryResult2, 2)
 
-		//First and second output record should contain first and second user's info, respectively
+		// First and second output record should contain first and second user's info, respectively
 		assert.Equal(user1, queryResult2[0])
 		assert.Equal(user2, queryResult2[1])
 	}
 
 	{
-		//Perform join, while making an assumption that the relationship between app and appUser is one-to-one
+		// Perform join, while making an assumption that the relationship between app and appUser is one-to-one
 		var queryResult1 app = app{}
 		var queryResult2 appUser = appUser{}
 		err := DataStore.PerformJoinOneToOne(ctx, &queryResult1, myCokeApp.GetId()[0].(string), &queryResult2, "app_id")
@@ -657,12 +663,12 @@ func TestJoinsDatabase(t *testing.T) {
 }
 
 func TestJoinsInMemory(t *testing.T) {
-	t.SkipNow() //Skip this test case for now - joins in an in-memory cache do not work for now. Would need to change the signature of join methods to make it work
+	t.SkipNow() // Skip this test case for now - joins in an in-memory cache do not work for now. Would need to change the signature of join methods to make it work
 	setupInMemoryCache(t)
 	testJoins(t, cokeAdminCtx)
 }
 
-// Not all fields contain a tag for column name
+// Not all fields contain a tag for column name.
 type appUserInvalid struct {
 	Id             string `db_column:"id" primary_key:"true"`
 	Name           string
@@ -677,7 +683,7 @@ func (appUser appUserInvalid) GetId() []interface{} {
 	return []interface{}{appUser.Id}
 }
 
-// Does not contain a tag for primary key
+// Does not contain a tag for primary key.
 type appUserInvalid2 struct {
 	Id             string `db_column:"id"`
 	Name           string `db_column:"name"`
@@ -692,7 +698,7 @@ func (appUser appUserInvalid2) GetId() []interface{} {
 	return []interface{}{appUser.Id}
 }
 
-// Contains a field with an unsupported data type (unsigned int)
+// Contains a field with an unsupported data type (unsigned int).
 type appUserInvalid3 struct {
 	Id             string `db_column:"id" primary_key:"true"`
 	Name           string `db_column:"name"`
@@ -707,7 +713,7 @@ func (appUser appUserInvalid3) GetId() []interface{} {
 	return []interface{}{appUser.Id}
 }
 
-// Contains a field with an unexported field
+// Contains a field with an unexported field.
 type appUserInvalid4 struct {
 	Id             string `db_column:"id" primary_key:"true"`
 	Name           string `db_column:"name"`
@@ -722,7 +728,7 @@ func (appUser appUserInvalid4) GetId() []interface{} {
 	return []interface{}{appUser.Id}
 }
 
-// Contains a primary_key tag that doesn't have a boolean value
+// Contains a primary_key tag that doesn't have a boolean value.
 type appUserInvalid5 struct {
 	Id             string `db_column:"id" primary_key:"xxx"`
 	Name           string `db_column:"name"`
@@ -737,7 +743,7 @@ func (appUser appUserInvalid5) GetId() []interface{} {
 	return []interface{}{appUser.Id}
 }
 
-// Contains duplicate values for db_column tag
+// Contains duplicate values for db_column tag.
 type appUserInvalid6 struct {
 	Id             string `db_column:"id" primary_key:"true"`
 	Name           string `db_column:"name"`
@@ -766,33 +772,33 @@ func testDALRegistration(t *testing.T, ctx context.Context) {
 	assert := assert.New(t)
 	roleMapping := map[string]DbRole{SERVICE_AUDITOR: READER}
 
-	//Not all fields contain a tag for column name
+	// Not all fields contain a tag for column name
 	assert.Panics(func() { _ = DataStore.RegisterWithDAL(ctx, roleMapping, appUserInvalid{}) })
 
-	//Does not contain a tag for primary key
+	// Does not contain a tag for primary key
 	assert.Panics(func() { _ = DataStore.RegisterWithDAL(ctx, roleMapping, appUserInvalid2{}) })
 
-	//Contains a field with an unsupported data type (unsigned int)
+	// Contains a field with an unsupported data type (unsigned int)
 	assert.Panics(func() { _ = DataStore.RegisterWithDAL(ctx, roleMapping, appUserInvalid3{}) })
 
-	//Contains a field with an unexported field
+	// Contains a field with an unexported field
 	assert.Panics(func() { _ = DataStore.RegisterWithDAL(ctx, roleMapping, appUserInvalid4{}) })
-	logger.Debug(appUserInvalid4{}.appId) //Need to use this field to pass lint
+	logger.Debug(appUserInvalid4{}.appId) // Need to use this field to pass lint
 
-	//Contains a primary_key tag that doesn't have a boolean value
+	// Contains a primary_key tag that doesn't have a boolean value
 	assert.Panics(func() { _ = DataStore.RegisterWithDAL(ctx, roleMapping, appUserInvalid5{}) })
 
-	//Contains duplicate DB column names (duplicate values for TAG_DB_COLUMN tag)
+	// Contains duplicate DB column names (duplicate values for TAG_DB_COLUMN tag)
 	assert.Panics(func() { _ = DataStore.RegisterWithDAL(ctx, roleMapping, appUserInvalid6{}) })
 
-	//When registering a struct with DAL, you should be able to pass it either by value or by reference
+	// When registering a struct with DAL, you should be able to pass it either by value or by reference
 	err := DataStore.RegisterWithDAL(ctx, roleMapping, app{})
 	assert.NoError(err)
 
 	err = DataStore.RegisterWithDAL(ctx, roleMapping, &appUser{})
 	assert.NoError(err)
 
-	//You should be able to register a struct that happens to have a name that's a reserved keyword in Postgres
+	// You should be able to register a struct that happens to have a name that's a reserved keyword in Postgres
 	err = DataStore.RegisterWithDAL(ctx, roleMapping, &group{})
 	assert.NoError(err)
 }
@@ -802,11 +808,10 @@ func TestDALRegistrationDatabase(t *testing.T) {
 	testDALRegistration(t, cokeAdminCtx)
 
 	assert := assert.New(t)
-	//Remove DB connections. Check if RegisterWithDAL() is still able to reconnect to DB
+	// Remove DB connections. Check if RegisterWithDAL() is still able to reconnect to DB
 	relationalDb.dbMap = make(map[DbRole]*sql.DB)
 	err := DataStore.RegisterWithDAL(cokeAdminCtx, map[string]DbRole{SERVICE_AUDITOR: READER}, &appUser{})
 	assert.NoError(err)
-
 }
 
 func TestDALRegistrationInMemory(t *testing.T) {
@@ -821,7 +826,7 @@ func TestDeleteWithMultipleCSPRoles(t *testing.T) {
 	const APP_ADMIN = "app_admin"
 	assert := assert.New(t)
 
-	//Create context for custom admin who will have 2 service roles
+	// Create context for custom admin who will have 2 service roles
 	customCtx := DataStore.GetAuthorizer().GetAuthContext(COKE, APP_ADMIN, SERVICE_ADMIN)
 	DataStore.Configure(customCtx, false, DataStore.GetAuthorizer())
 
@@ -829,47 +834,47 @@ func TestDeleteWithMultipleCSPRoles(t *testing.T) {
 		assert.FailNow("Failed to drop DB tables for the following reason:\n" + err.Error())
 	}
 
-	//The custom admin will have a read access being an app admin and read & write access being a service admin
+	// The custom admin will have a read access being an app admin and read & write access being a service admin
 	roleMapping := map[string]DbRole{APP_ADMIN: READER, SERVICE_ADMIN: WRITER}
 	err := DataStore.RegisterWithDAL(customCtx, roleMapping, app{})
 	if err != nil {
 		assert.FailNow("Failed to setup the test case for the following reason:\n")
 	}
 
-	//Add some data to the app table
+	// Add some data to the app table
 	prepareInput()
 	if _, err = DataStore.Insert(cokeAdminCtx, myCokeApp); err != nil {
 		assert.FailNow("Failed to prepare data for the test case for the following reason:\n" + err.Error())
 	}
 
-	//Make sure that the custom admin is able to delete the data
+	// Make sure that the custom admin is able to delete the data
 	rowsAffected, err := DataStore.Delete(customCtx, myCokeApp)
 	assert.NoError(err)
 	assert.EqualValues(1, rowsAffected)
 }
 
 /*
-Tries to perform a query with a service role that has not been authorized to access the table
+Tries to perform a query with a service role that has not been authorized to access the table.
 */
 func TestUnauthorizedAccess(t *testing.T) {
 	assert := assert.New(t)
 	setupDbTables(t)
 
 	ctx := DataStore.GetAuthorizer().GetAuthContext(COKE, "unauthorized service role")
-	var queryResult = app{Id: myCokeApp.Id, OrgId: PEPSI}
+	queryResult := app{Id: myCokeApp.Id, OrgId: PEPSI}
 	err := DataStore.Find(ctx, &queryResult)
 	assert.ErrorIs(err, ErrOperationNotAllowed)
 }
 
 /*
-Tries CRUD operations with Pepsi's org ID in the context, while the data in DB belongs to Coke
+Tries CRUD operations with Pepsi's org ID in the context, while the data in DB belongs to Coke.
 */
 func testCrudWithMismatchingOrgId(t *testing.T, cokeCtx context.Context) {
 	assert := assert.New(t)
 	tenantStr := "tenant=Pepsi"
 	orgIdStr := "orgIdCol=Coke"
 
-	//Try to perform CRUD operations on Coke's data as a user from Pepsi
+	// Try to perform CRUD operations on Coke's data as a user from Pepsi
 	{
 		var queryResult1 app = app{}
 		var queryResult2 appUserSlice = make([]appUser, 1)
@@ -891,7 +896,7 @@ func testCrudWithMismatchingOrgId(t *testing.T, cokeCtx context.Context) {
 	{
 		var queryResult app = app{Id: myCokeApp.Id, OrgId: myCokeApp.OrgId}
 		err := DataStore.Find(pepsiAdminCtx, &queryResult)
-		assert.ErrorIs(err, ErrOperationNotAllowed) //Trying to read another tenant's data should return an error
+		assert.ErrorIs(err, ErrOperationNotAllowed) // Trying to read another tenant's data should return an error
 		assert.True(strings.Contains(err.Error(), tenantStr), err.Error())
 		assert.True(strings.Contains(err.Error(), orgIdStr), err.Error())
 	}
@@ -899,10 +904,10 @@ func testCrudWithMismatchingOrgId(t *testing.T, cokeCtx context.Context) {
 	{
 		queryResult := make([]app, 0)
 		err := DataStore.FindAll(pepsiAdminCtx, &queryResult)
-		assert.NoError(err)       //Pepsi tried to read all the records in DB - no error should be returned
-		assert.Empty(queryResult) //But Pepsi should not see Coke's data
+		assert.NoError(err)       // Pepsi tried to read all the records in DB - no error should be returned
+		assert.Empty(queryResult) // But Pepsi should not see Coke's data
 
-		//Try to read a specific record from DB that definitely exists but belongs to another tenant
+		// Try to read a specific record from DB that definitely exists but belongs to another tenant
 		queryResult = make([]app, 0)
 		err = DataStore.FindWithFilter(pepsiAdminCtx, &myCokeApp, &queryResult)
 		assert.ErrorIs(err, ErrOperationNotAllowed)
@@ -912,9 +917,9 @@ func testCrudWithMismatchingOrgId(t *testing.T, cokeCtx context.Context) {
 
 	{
 		_, err := DataStore.Delete(pepsiAdminCtx, myCokeApp)
-		assert.ErrorIs(err, ErrOperationNotAllowed) //Trying to delete another tenant's data should return an error
+		assert.ErrorIs(err, ErrOperationNotAllowed) // Trying to delete another tenant's data should return an error
 		queryResult := app{Id: myCokeApp.Id, OrgId: myCokeApp.OrgId}
-		err = DataStore.Find(cokeCtx, &queryResult) //Since the previous delete has failed, the data should still be in the DB
+		err = DataStore.Find(cokeCtx, &queryResult) // Since the previous delete has failed, the data should still be in the DB
 		assert.NoError(err)
 		assert.NotEmpty(queryResult)
 	}
@@ -926,12 +931,12 @@ func testCrudWithMismatchingOrgId(t *testing.T, cokeCtx context.Context) {
 			OrgId: COKE,
 		}
 
-		//You should not be able to insert another tenant's data into data store
+		// You should not be able to insert another tenant's data into data store
 		rowsAffected, err := DataStore.Insert(pepsiAdminCtx, newApp)
 		assert.ErrorIs(err, ErrOperationNotAllowed)
 		assert.Equal(int64(0), rowsAffected)
 
-		//Another tenant's data should not be found because it should not have been inserted into the data store
+		// Another tenant's data should not be found because it should not have been inserted into the data store
 		queryResult := app{Id: newApp.Id, OrgId: newApp.OrgId}
 		err = DataStore.Find(cokeCtx, &queryResult)
 		assert.ErrorIs(err, RecordNotFoundError)
@@ -939,13 +944,13 @@ func testCrudWithMismatchingOrgId(t *testing.T, cokeCtx context.Context) {
 	}
 
 	{
-		//App without an org. ID
+		// App without an org. ID
 		newApp := app{
 			Id:   "id-" + strconv.Itoa(rand.Int()),
 			Name: "New app",
 		}
 
-		//You should not be able to insert a "multi-tenant" record that lacks the org. ID
+		// You should not be able to insert a "multi-tenant" record that lacks the org. ID
 		rowsAffected, err := DataStore.Insert(pepsiAdminCtx, newApp)
 		assert.ErrorIs(err, ErrorExecutingSqlStmt)
 		assert.Equal(int64(0), rowsAffected)
@@ -954,14 +959,14 @@ func testCrudWithMismatchingOrgId(t *testing.T, cokeCtx context.Context) {
 	{
 		updatedApp := myCokeApp
 		updatedApp.Name = "new name"
-		_, err := DataStore.Update(pepsiAdminCtx, updatedApp) //You shouldn't be able to update another tenant's data with a tenant-specific role
+		_, err := DataStore.Update(pepsiAdminCtx, updatedApp) // You shouldn't be able to update another tenant's data with a tenant-specific role
 		assert.ErrorIs(err, ErrOperationNotAllowed)
 
 		queryResult := app{Id: myCokeApp.Id, OrgId: myCokeApp.OrgId}
 		err = DataStore.Find(cokeCtx, &queryResult)
 		assert.NoError(err)
-		assert.NotEqual(updatedApp.Name, queryResult.Name) //Record should not have been updated
-		assert.Equal(myCokeApp.Name, queryResult.Name)     //Record should not have been updated
+		assert.NotEqual(updatedApp.Name, queryResult.Name) // Record should not have been updated
+		assert.Equal(myCokeApp.Name, queryResult.Name)     // Record should not have been updated
 	}
 }
 
@@ -1009,13 +1014,13 @@ func TestWithBlankEnvVar(t *testing.T) {
 
 /*
 Checks that you can correctly sort DB roles based how restrictive they are (most restrictive to the least restrictive roles).
-E.g., tenant_reader more restrictive than reader
+E.g., tenant_reader more restrictive than reader.
 */
 func TestDbRoleSorting(t *testing.T) {
 	assert := assert.New(t)
 
 	var roles DbRoleSlice = []DbRole{WRITER, TENANT_WRITER, READER, TENANT_READER}
-	var writerIndex, tenantWriterIndex, readerIndex, tenantReaderIndex = 0, 1, 2, 3
+	writerIndex, tenantWriterIndex, readerIndex, tenantReaderIndex := 0, 1, 2, 3
 	assert.False(roles.Less(writerIndex, tenantWriterIndex))
 	assert.False(roles.Less(tenantWriterIndex, readerIndex))
 	assert.False(roles.Less(readerIndex, tenantReaderIndex))
@@ -1026,7 +1031,7 @@ func TestDbRoleSorting(t *testing.T) {
 }
 
 /*
-Tests revision blocking updates that are outdated
+Tests revision blocking updates that are outdated.
 */
 func TestRevision(t *testing.T) {
 	assert := assert.New(t)
@@ -1044,20 +1049,20 @@ func TestRevision(t *testing.T) {
 
 	err := DataStore.RegisterWithDAL(cokeAdminCtx, roleMapping, group{})
 	assert.NoError(err)
-	var myGroup = group{Id: "withRevisionId-12345", Name: "withRevisionName"}
+	myGroup := group{Id: "withRevisionId-12345", Name: "withRevisionName"}
 
-	//FIXME Initial revision should be 1
+	// FIXME Initial revision should be 1
 	const initialRevision int = 0
 
 	_, err = DataStore.Insert(cokeAdminCtx, myGroup)
 	assert.NoError(err)
 
-	var actualQueryResult, expectedQueryResult = group{Id: myGroup.Id}, group{Id: "withRevisionId-12345", Name: "withRevisionName", Revision: initialRevision}
+	actualQueryResult, expectedQueryResult := group{Id: myGroup.Id}, group{Id: "withRevisionId-12345", Name: "withRevisionName", Revision: initialRevision}
 	err = DataStore.Find(cokeAdminCtx, &actualQueryResult)
 	assert.NoError(err)
 	assert.Equal(expectedQueryResult, actualQueryResult)
 
-	//update should  succeed when revision is the same as the value in the db
+	// update should  succeed when revision is the same as the value in the db
 	updatedGroup := group{Id: myGroup.Id, Name: "updatedGroup", Revision: initialRevision}
 	rowsAffected, err := DataStore.Update(cokeAdminCtx, updatedGroup)
 	assert.NoError(err)
@@ -1068,7 +1073,7 @@ func TestRevision(t *testing.T) {
 	assert.Equal(initialRevision+1, actualQueryResult.Revision, "Expected revision to be incremented by 1 after update")
 	assert.Equal(updatedGroup.Name, actualQueryResult.Name)
 
-	//upsert should  succeed when revision is the same as the value in the db
+	// upsert should  succeed when revision is the same as the value in the db
 	updatedGroup = group{Id: myGroup.Id, Name: "updatedGroup2", Revision: actualQueryResult.Revision}
 	rowsAffected, err = DataStore.Upsert(cokeAdminCtx, updatedGroup)
 	assert.NoError(err)
@@ -1079,7 +1084,7 @@ func TestRevision(t *testing.T) {
 	assert.Equal(initialRevision+2, actualQueryResult.Revision, "Expected revision to be incremented by 1 after upsert")
 	assert.Equal(updatedGroup.Name, actualQueryResult.Name)
 
-	//update should fail when revision is not equal to the value in the db
+	// update should fail when revision is not equal to the value in the db
 	updatedGroup = group{Id: myGroup.Id, Name: "updatedGroup3", Revision: initialRevision + 100}
 	_, err = DataStore.Update(cokeAdminCtx, updatedGroup)
 	assert.ErrorIs(err, RevisionConflictError)
@@ -1089,7 +1094,7 @@ func TestRevision(t *testing.T) {
 	assert.NotEqual(updatedGroup.Revision+1, actualQueryResult.Revision)
 	assert.NotEqual(updatedGroup.Name, actualQueryResult.Name)
 
-	//upsert should fail when revision is not equal to the value in the db
+	// upsert should fail when revision is not equal to the value in the db
 	updatedGroup = group{Id: myGroup.Id, Name: "updatedGroup4", Revision: initialRevision + 100}
 	_, err = DataStore.Upsert(cokeAdminCtx, updatedGroup)
 	assert.ErrorIs(err, RevisionConflictError)
@@ -1099,9 +1104,8 @@ func TestRevision(t *testing.T) {
 	assert.NotEqual(updatedGroup.Revision+1, actualQueryResult.Revision)
 	assert.NotEqual(updatedGroup.Name, actualQueryResult.Name)
 
-	//upsert should fail when revision is less than the value in the db
+	// upsert should fail when revision is less than the value in the db
 	updatedGroup = group{Id: myGroup.Id, Name: "updatedGroup4", Revision: 1}
 	_, err = DataStore.Upsert(cokeAdminCtx, updatedGroup)
 	assert.ErrorIs(err, RevisionConflictError)
-
 }

--- a/data-access-layer/datastore/error_codes.go
+++ b/data-access-layer/datastore/error_codes.go
@@ -42,7 +42,7 @@ const (
 )
 
 func contextToString(ctx interface{}) string {
-	var ctxStr = ""
+	ctxStr := ""
 	contextValues := reflect.ValueOf(ctx).Elem()
 	contextKeys := reflect.TypeOf(ctx).Elem()
 
@@ -56,11 +56,12 @@ func contextToString(ctx interface{}) string {
 			if reflectField.Name == "Context" {
 				ctxStr += contextToString(reflectValue.Interface())
 			} else {
-				if reflectField.Name == "key" {
+				switch reflectField.Name {
+				case "key":
 					ctxStr += fmt.Sprintf(" %+v=", reflectValue.Interface())
-				} else if reflectField.Name == "val" {
+				case "val":
 					ctxStr += fmt.Sprintf("%+v,", reflectValue.Interface())
-				} else {
+				default:
 					ctxStr += fmt.Sprintf("%+v=%+v,", reflectField.Name, reflectValue.Interface())
 				}
 			}
@@ -76,7 +77,7 @@ type DbError struct {
 }
 
 func (e *DbError) Error() string {
-	var str = e.msg
+	str := e.msg
 	if e.err != nil {
 		str = str + ": " + e.err.Error()
 	}
@@ -127,7 +128,7 @@ func (c ErrorContextKey) String() string {
 }
 
 func (e *DbError) WithValue(key ErrorContextKey, value string) *DbError {
-	var ctx = e.ctx
+	ctx := e.ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -139,7 +140,7 @@ func (e *DbError) WithValue(key ErrorContextKey, value string) *DbError {
 }
 
 func (e *DbError) WithMap(kvMap map[ErrorContextKey]string) *DbError {
-	var ctx = e.ctx
+	ctx := e.ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/data-access-layer/datastore/inmemory.go
+++ b/data-access-layer/datastore/inmemory.go
@@ -54,7 +54,7 @@ func (inMemory *InMemory) GetAuthorizer() Authorizer {
 }
 
 /*
-Reset all the caches in memory and mutexes
+Reset all the caches in memory and mutexes.
 */
 func (inMemory *InMemory) Reset() {
 	inMemory.caches = make(map[string](map[string]Record))
@@ -63,7 +63,7 @@ func (inMemory *InMemory) Reset() {
 }
 
 /*
-Initializes the in-memory caches and their mutexes
+Initializes the in-memory caches and their mutexes.
 */
 func (inMemory *InMemory) initialize(cacheName string) {
 	// If registered caches map hasn't been initialized, do so
@@ -129,7 +129,7 @@ Assumes the relationship between record1 and record2 is one-to-many.
 Stores the retrieved record from the first cache in record1 argument, and the matching
 records from the second cache in query2Output argument.
 */
-// TODO - if the first cache contains the record but the second one doesn't, don't return anything
+// TODO - if the first cache contains the record but the second one doesn't, don't return anything.
 func (inMemory *InMemory) PerformJoinOneToMany(ctx context.Context, record1 Record, record1Id string, record2JoinOnColumn string, query2Output interface{}) error {
 	if err := validateIdAndRecordPtr(record1Id, record1); err != nil {
 		return err
@@ -160,7 +160,7 @@ func (inMemory *InMemory) PerformJoinOneToMany(ctx context.Context, record1 Reco
 	}
 
 	query2OutputValue := reflect.ValueOf(query2Output).Elem()
-	var size = query2OutputValue.Len()
+	size := query2OutputValue.Len()
 	for i := 0; i < size; i++ {
 		record := query2OutputValue.Index(i)
 
@@ -234,6 +234,7 @@ records must be a pointer to a slice of structs.
 func (inMemory *InMemory) FindWithFilter(ctx context.Context, record Record, records interface{}) error {
 	return inMemory.FindWithFilterInTable(ctx, GetTableName(record), record, records)
 }
+
 func (inMemory *InMemory) FindWithFilterInTable(ctx context.Context, cacheName string, record Record, records interface{}) error {
 	// Validate arguments
 	if reflect.TypeOf(records).Kind() != reflect.Ptr || reflect.TypeOf(records).Elem().Kind() != reflect.Slice {
@@ -273,6 +274,7 @@ record must be a struct.
 func (inMemory *InMemory) Insert(ctx context.Context, record Record) (int64, error) {
 	return inMemory.InsertInTable(ctx, GetTableName(record), record)
 }
+
 func (inMemory *InMemory) InsertInTable(_ context.Context, cacheName string, record Record) (int64, error) {
 	var id string = record.GetId()[0].(string)
 	if err := validateIdAndRecordStruct(id, record); err != nil {
@@ -341,7 +343,7 @@ func (inMemory *InMemory) Drop(tableNames ...string) error {
 }
 
 /*
-Deletes all records from cache
+Deletes all records from cache.
 */
 func (inMemory *InMemory) Truncate(tableNames ...string) error {
 	inMemory.cacheMapMutex.Lock()
@@ -407,6 +409,7 @@ func (inMemory *InMemory) UpsertInTable(ctx context.Context, cacheName string, r
 func (inMemory *InMemory) RegisterWithDAL(ctx context.Context, roleMapping map[string]DbRole, record Record) error {
 	return inMemory.RegisterWithDALHelper(ctx, roleMapping, GetTableName(record), record)
 }
+
 func (inMemory *InMemory) RegisterWithDALHelper(_ context.Context, roleMapping map[string]DbRole, cacheName string, record Record) error {
 	logger.Debugf("Registering the struct %q with DAL (backed by an in-memory cache)... Using authorizer %s...", cacheName, GetTableName(inMemory.authorizer))
 
@@ -416,14 +419,14 @@ func (inMemory *InMemory) RegisterWithDALHelper(_ context.Context, roleMapping m
 }
 
 /*
-Configures data store to use Postgres or an in-memory cache
+Configures data store to use Postgres or an in-memory cache.
 */
 func (inMemory *InMemory) Configure(_ context.Context, isDataStoreInMemory bool, authorizer Authorizer) {
 	configureDataStore(isDataStoreInMemory, authorizer)
 }
 
 /*
-Copies contents of source, which is a struct, to dest, which is a pointer to a struct
+Copies contents of source, which is a struct, to dest, which is a pointer to a struct.
 */
 func copyRecord(source, dest Record) {
 	destRecordValue := reflect.ValueOf(dest).Elem()

--- a/data-access-layer/datastore/protostore.go
+++ b/data-access-layer/datastore/protostore.go
@@ -133,8 +133,7 @@ func MetadataFrom(protoStoreMsg ProtoStoreMsg) Metadata {
 	}
 }
 
-type ProtobufDataStore struct {
-}
+type ProtobufDataStore struct{}
 
 func (p ProtobufDataStore) GetAuthorizer() Authorizer {
 	return Helper.GetAuthorizer()
@@ -160,7 +159,7 @@ func (p ProtobufDataStore) Register(ctx context.Context, roleMapping map[string]
 }
 
 /*
-Inserts a Protobuf message with the given id and belonging to the given org. into data store
+Inserts a Protobuf message with the given id and belonging to the given org. into data store.
 */
 func (p ProtobufDataStore) Insert(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error) {
 	return p.InsertWithMetadata(ctx, id, msg, Metadata{})
@@ -177,7 +176,7 @@ func (p ProtobufDataStore) InsertWithMetadata(ctx context.Context, id string, ms
 		return 0, Metadata{}, err
 	}
 
-	var protoStoreMsg = ProtoStoreMsg{
+	protoStoreMsg := ProtoStoreMsg{
 		Id:       id,
 		Msg:      bytes,
 		ParentId: metadata.ParentId,
@@ -203,7 +202,7 @@ func (p ProtobufDataStore) InsertWithMetadata(ctx context.Context, id string, ms
 /*
 Fetches metadata for the record and updates the Protobuf message.
 NOTE: Avoid using this method in user-workflows and only in service-to-service workflows
-when the updates are already ordered by some other service/app
+when the updates are already ordered by some other service/app.
 */
 func (p ProtobufDataStore) Update(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error) {
 	md, err = p.GetMetadata(ctx, id, msg)
@@ -214,7 +213,7 @@ func (p ProtobufDataStore) Update(ctx context.Context, id string, msg proto.Mess
 }
 
 /*
-Updates a Protobuf message
+Updates a Protobuf message.
 */
 func (p ProtobufDataStore) UpdateWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (rowsAffected int64, md Metadata, err error) {
 	bytes, err := ToBytes(msg)
@@ -227,7 +226,7 @@ func (p ProtobufDataStore) UpdateWithMetadata(ctx context.Context, id string, ms
 		return 0, Metadata{}, err
 	}
 
-	var protoStoreMsg = ProtoStoreMsg{
+	protoStoreMsg := ProtoStoreMsg{
 		Id:       id,
 		Msg:      bytes,
 		ParentId: metadata.ParentId,
@@ -248,7 +247,7 @@ func (p ProtobufDataStore) UpdateWithMetadata(ctx context.Context, id string, ms
 /*
 Fetches metadata for the record and upserts the Protobuf message.
 NOTE: Avoid using this method in user-workflows and only in service-to-service workflows
-when the updates are already ordered by some other service/app
+when the updates are already ordered by some other service/app.
 */
 func (p ProtobufDataStore) Upsert(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error) {
 	md, err = p.GetMetadata(ctx, id, msg)
@@ -264,7 +263,8 @@ func (p ProtobufDataStore) Upsert(ctx context.Context, id string, msg proto.Mess
 }
 
 func (p ProtobufDataStore) UpsertWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (
-	rowsAffected int64, md Metadata, err error) {
+	rowsAffected int64, md Metadata, err error,
+) {
 	bytes, err := ToBytes(msg)
 	if err != nil {
 		return 0, Metadata{}, err
@@ -275,7 +275,7 @@ func (p ProtobufDataStore) UpsertWithMetadata(ctx context.Context, id string, ms
 		return 0, Metadata{}, err
 	}
 
-	var protoStoreMsg = ProtoStoreMsg{
+	protoStoreMsg := ProtoStoreMsg{
 		Id:       id,
 		Msg:      bytes,
 		ParentId: metadata.ParentId,
@@ -301,13 +301,12 @@ Finds a Protobuf message by ID.
 If metadata arg. is non-nil, fills it with the metadata (parent ID & revision) of the Protobuf message that was found.
 */
 func (p ProtobufDataStore) FindById(ctx context.Context, id string, msg proto.Message, metadata *Metadata) error {
-
 	orgId, err := Helper.GetAuthorizer().GetOrgFromContext(ctx)
 	if err != nil {
 		return err
 	}
 
-	var protoStoreMsg = ProtoStoreMsg{
+	protoStoreMsg := ProtoStoreMsg{
 		Id:    id,
 		OrgId: orgId,
 	}
@@ -322,13 +321,12 @@ func (p ProtobufDataStore) FindById(ctx context.Context, id string, msg proto.Me
 }
 
 func (p ProtobufDataStore) GetMetadata(ctx context.Context, id string, msg proto.Message) (md Metadata, err error) {
-
 	orgId, err := Helper.GetAuthorizer().GetOrgFromContext(ctx)
 	if err != nil {
 		return md, err
 	}
 
-	var protoStoreMsg = ProtoStoreMsg{
+	protoStoreMsg := ProtoStoreMsg{
 		Id:    id,
 		OrgId: orgId,
 	}
@@ -374,7 +372,7 @@ func (p ProtobufDataStore) FindAllAsMap(ctx context.Context, msgsMap interface{}
 		False if msgsMap is a map of strings to STRUCTS
 	*/
 	var isMsgsElemPtrToStructs bool = reflect.TypeOf(msgsMap).Elem().Kind() == reflect.Ptr
-	var tableName = GetTableNameFromSlice(msgsMap)
+	tableName := GetTableNameFromSlice(msgsMap)
 
 	protoStoreMsgs := make([]ProtoStoreMsg, 0)
 	err = Helper.FindAllInTable(ctx, tableName, &protoStoreMsgs)
@@ -383,7 +381,7 @@ func (p ProtobufDataStore) FindAllAsMap(ctx context.Context, msgsMap interface{}
 	}
 
 	metadataMap = make(map[string]Metadata, len(protoStoreMsgs))
-	var msgsMapValue = reflect.ValueOf(msgsMap)
+	msgsMapValue := reflect.ValueOf(msgsMap)
 
 	for _, protoStoreMsg := range protoStoreMsgs {
 		// Empty instance of a Protobuf message
@@ -425,7 +423,7 @@ func (p ProtobufDataStore) FindAll(ctx context.Context, msgs interface{}) (metad
 		False if msgs is a pointer to a slice of structs
 	*/
 	var isSlicePtrToStructs bool = reflect.TypeOf(msgs).Elem().Elem().Kind() == reflect.Ptr
-	var tableName = GetTableNameFromSlice(msgs)
+	tableName := GetTableNameFromSlice(msgs)
 
 	protoStoreMsgs := make([]ProtoStoreMsg, 0)
 	err = Helper.FindAllInTable(ctx, tableName, &protoStoreMsgs)
@@ -466,7 +464,7 @@ func (p ProtobufDataStore) DeleteById(ctx context.Context, id string, msg proto.
 		return 0, err
 	}
 
-	var protoStoreMsg = ProtoStoreMsg{
+	protoStoreMsg := ProtoStoreMsg{
 		Id:    id,
 		OrgId: orgId,
 	}

--- a/data-access-layer/datastore/protostore_mock.go
+++ b/data-access-layer/datastore/protostore_mock.go
@@ -88,19 +88,22 @@ func (p *ProtoStoreMock) DeleteById(ctx context.Context, id string, msg proto.Me
 }
 
 func (p *ProtoStoreMock) InsertWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (
-	rowsAffected int64, md Metadata, err error) {
+	rowsAffected int64, md Metadata, err error,
+) {
 	args := p.Called(ctx, id, msg, metadata)
 	return args.Get(0).(int64), args.Get(1).(Metadata), args.Error(2)
 }
 
 func (p *ProtoStoreMock) UpdateWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (
-	rowsAffected int64, md Metadata, err error) {
+	rowsAffected int64, md Metadata, err error,
+) {
 	args := p.Called(ctx, id, msg, metadata)
 	return args.Get(0).(int64), args.Get(1).(Metadata), args.Error(2)
 }
 
 func (p *ProtoStoreMock) UpsertWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (
-	rowsAffected int64, md Metadata, err error) {
+	rowsAffected int64, md Metadata, err error,
+) {
 	args := p.Called(ctx, id, msg, metadata)
 	return args.Get(0).(int64), args.Get(1).(Metadata), args.Error(2)
 }

--- a/data-access-layer/datastore/protostore_mock_test.go
+++ b/data-access-layer/datastore/protostore_mock_test.go
@@ -47,8 +47,8 @@ func TestProtoStoreMock(t *testing.T) {
 	myMockProtoStore.On("Configure", mock.Anything, mock.Anything, mock.Anything).Return()
 	myMockProtoStore.On("GetAuthorizer").Return(MetadataBasedAuthorizer{})
 
-	//Confirm that ProtoStoreMock implements all methods of ProtoStore
-	//Modifying the signature of any method of ProtoStore will lead to the line below not compiling
+	// Confirm that ProtoStoreMock implements all methods of ProtoStore
+	// Modifying the signature of any method of ProtoStore will lead to the line below not compiling
 	var myProtoStore ProtoStore = myMockProtoStore
 
 	ctx := context.TODO()
@@ -69,7 +69,7 @@ func TestProtoStoreMock(t *testing.T) {
 	_, _ = myProtoStore.GetRevision(ctx, "001", &pb.CPU{})
 	_ = myProtoStore.GetAuthorizer()
 
-	//Check that each ProtoStore method invocation is actually registered in the mock
+	// Check that each ProtoStore method invocation is actually registered in the mock
 	myMockProtoStore.AssertCalled(t, "DropTables", mock.Anything)
 	myMockProtoStore.AssertCalled(t, "Register", mock.Anything, mock.Anything, mock.Anything)
 	myMockProtoStore.AssertCalled(t, "Insert", mock.Anything, mock.Anything, mock.Anything)
@@ -84,5 +84,4 @@ func TestProtoStoreMock(t *testing.T) {
 	myMockProtoStore.AssertCalled(t, "GetRevision", mock.Anything, mock.Anything, mock.Anything)
 	myMockProtoStore.AssertCalled(t, "Configure", mock.Anything, mock.Anything, mock.Anything)
 	myMockProtoStore.AssertCalled(t, "GetAuthorizer")
-
 }

--- a/data-access-layer/datastore/protostore_test.go
+++ b/data-access-layer/datastore/protostore_test.go
@@ -24,13 +24,11 @@ import (
 	"sort"
 	"testing"
 
-	"google.golang.org/protobuf/proto"
-
 	faker "github.com/bxcodec/faker/v3"
 	log "github.com/sirupsen/logrus"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware-labs/multi-tenant-persistence-for-saas/test/pb"
+	"google.golang.org/protobuf/proto"
 )
 
 var protoMsgs = []proto.Message{
@@ -43,6 +41,7 @@ type MemorySlice []pb.Memory
 func (s MemorySlice) Len() int {
 	return len(s)
 }
+
 func (s MemorySlice) Less(i, j int) bool {
 	return s[i].String() < s[j].String()
 }
@@ -59,15 +58,13 @@ type MemoryPtrSlice []*pb.Memory
 func (s MemoryPtrSlice) Len() int {
 	return len(s)
 }
+
 func (s MemoryPtrSlice) Less(i, j int) bool {
 	return s[i].String() < s[j].String()
 }
 
 func (s MemoryPtrSlice) Swap(i, j int) {
-
-	copy := s[i]
-	s[i] = s[j]
-	s[j] = copy
+	s[i], s[j] = s[j], s[i]
 }
 
 type CPUSlice []pb.CPU
@@ -75,6 +72,7 @@ type CPUSlice []pb.CPU
 func (s CPUSlice) Len() int {
 	return len(s)
 }
+
 func (s CPUSlice) Less(i, j int) bool {
 	return s[i].String() < s[j].String()
 }
@@ -93,14 +91,13 @@ type CPUPtrSlice []*pb.CPU
 func (s CPUPtrSlice) Len() int {
 	return len(s)
 }
+
 func (s CPUPtrSlice) Less(i, j int) bool {
 	return s[i].String() < s[j].String()
 }
 
 func (s CPUPtrSlice) Swap(i, j int) {
-	copy := s[i]
-	s[i] = s[j]
-	s[j] = copy
+	s[i], s[j] = s[j], s[i]
 }
 
 const (
@@ -111,10 +108,10 @@ const (
 
 func TestProtoConversionWithFaker(t *testing.T) {
 	assert := assert.New(t)
-	var msg1 = pb.CPU{}
+	msg1 := pb.CPU{}
 	_ = faker.FakeData(&msg1)
 	data, _ := ToBytes(&msg1)
-	var msg2 = pb.CPU{}
+	msg2 := pb.CPU{}
 	_ = FromBytes(data, &msg2)
 
 	assert.Equal(msg1.String(), msg2.String())
@@ -122,7 +119,7 @@ func TestProtoConversionWithFaker(t *testing.T) {
 
 func TestProtoConversion(t *testing.T) {
 	assert := assert.New(t)
-	var msg1 = pb.CPU{
+	msg1 := pb.CPU{
 		Brand:         "Intel",
 		Name:          "Pentium",
 		NumberCores:   4,
@@ -130,19 +127,19 @@ func TestProtoConversion(t *testing.T) {
 		MinGhz:        1.6,
 	}
 	data, _ := ToBytes(&msg1)
-	var msg2 = pb.CPU{}
+	msg2 := pb.CPU{}
 	_ = FromBytes(data, &msg2)
 
 	assert.Equal(msg1.String(), msg2.String())
 
-	var msg3 = pb.Memory{
+	msg3 := pb.Memory{
 		Brand: "Samsung",
 		Size:  32,
 		Speed: 2933,
 		Type:  "DDR4",
 	}
 	data, _ = ToBytes(&msg3)
-	var msg4 = pb.Memory{}
+	msg4 := pb.Memory{}
 	_ = FromBytes(data, &msg4)
 
 	assert.Equal(msg3.String(), msg4.String())
@@ -209,9 +206,9 @@ func testProtoStoreFindWithInvalidParams(t *testing.T, ctx context.Context) {
 	assert := assert.New(t)
 	var p ProtoStore = GetProtoStore()
 
-	//FIND ALL
+	// FIND ALL
 	{
-		var invalidParams = []interface{}{
+		invalidParams := []interface{}{
 			pb.CPU{},
 			&pb.CPU{},
 			[]pb.CPU{},
@@ -220,26 +217,26 @@ func testProtoStoreFindWithInvalidParams(t *testing.T, ctx context.Context) {
 		}
 
 		for i := range invalidParams {
-			var invalidParam = invalidParams[i]
+			invalidParam := invalidParams[i]
 			_, err := p.FindAll(ctx, invalidParam)
 			assert.ErrorIs(err, IllegalArgumentError)
 		}
 
-		var validParams = []interface{}{
+		validParams := []interface{}{
 			&[]pb.CPU{},
 			&[]*pb.CPU{},
 		}
 
 		for i := range validParams {
-			var validParam = validParams[i]
+			validParam := validParams[i]
 			_, err := p.FindAll(ctx, validParam)
 			assert.NoError(err)
 		}
 	}
 
-	//FIND ALL AS MAP
+	// FIND ALL AS MAP
 	{
-		var invalidParams = []interface{}{
+		invalidParams := []interface{}{
 			pb.CPU{},
 			&pb.CPU{},
 			[]pb.CPU{},
@@ -248,18 +245,18 @@ func testProtoStoreFindWithInvalidParams(t *testing.T, ctx context.Context) {
 		}
 
 		for i := range invalidParams {
-			var invalidParam = invalidParams[i]
+			invalidParam := invalidParams[i]
 			_, err := p.FindAllAsMap(ctx, invalidParam)
 			assert.ErrorIs(err, IllegalArgumentError)
 		}
 
-		var validParams = []interface{}{
+		validParams := []interface{}{
 			map[string]*pb.CPU{},
 			map[string]pb.CPU{},
 		}
 
 		for i := range validParams {
-			var validParam = validParams[i]
+			validParam := validParams[i]
 			_, err := p.FindAllAsMap(ctx, validParam)
 			assert.NoError(err)
 		}
@@ -279,14 +276,14 @@ func TestProtoStoreInMemoryFindAll(t *testing.T) {
 /*
 Checks if DIFFERENT types of Protobuf messages can be persisted with the same IDs.
 Checks if FindAll() works (both when query results are stored in a ptr to a slice of structs and
-when query results are stored in a ptr to a slice of ptrs to structs )
+when query results are stored in a ptr to a slice of ptrs to structs ).
 */
 func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 	assert := assert.New(t)
 	var p ProtoStore = GetProtoStore()
 
-	//Prepare data for test cases
-	var memmsg1, memmsg2, cpumsg1, cpumsg2 = pb.Memory{}, pb.Memory{}, pb.CPU{}, pb.CPU{}
+	// Prepare data for test cases
+	memmsg1, memmsg2, cpumsg1, cpumsg2 := pb.Memory{}, pb.Memory{}, pb.CPU{}, pb.CPU{}
 	for _, protoMsg := range []proto.Message{&memmsg1, &memmsg2, &cpumsg1, &cpumsg2} {
 		_ = faker.FakeData(protoMsg)
 	}
@@ -320,7 +317,7 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 	sort.Sort(expectedCPUQueryResults)
 
 	{
-		//Check if you can find all memory records when passing a pointer to slice of structs
+		// Check if you can find all memory records when passing a pointer to slice of structs
 		var actualQueryResults MemorySlice = make([]pb.Memory, 0)
 		metadataMap, err := p.FindAll(ctx, &actualQueryResults)
 		assert.NoError(err)
@@ -333,7 +330,7 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 	}
 
 	{
-		//Check if you can find all memory records when passing a pointer to slice of pointers to structs
+		// Check if you can find all memory records when passing a pointer to slice of pointers to structs
 		var actualQueryResults MemoryPtrSlice = make([]*pb.Memory, 0)
 		metadataMap, err := p.FindAll(ctx, &actualQueryResults)
 		assert.NoError(err)
@@ -346,14 +343,14 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 	}
 
 	{
-		//Check if you can find all memory records when passing a pointer to map of strings to structs
-		var actualQueryResults = make(map[string]pb.Memory)
+		// Check if you can find all memory records when passing a pointer to map of strings to structs
+		actualQueryResults := make(map[string]pb.Memory)
 		metadataMap, err := p.FindAllAsMap(ctx, actualQueryResults)
 		assert.NoError(err)
 		assert.Len(actualQueryResults, 2)
 		assert.Len(metadataMap, 2)
 
-		var expectedQueryResults = make(map[string]pb.Memory)
+		expectedQueryResults := make(map[string]pb.Memory)
 		expectedQueryResults[P1] = pb.Memory{
 			Brand: memmsg1.Brand,
 			Size:  memmsg1.Size,
@@ -368,13 +365,13 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 		}
 
 		for _, id := range []string{P1, P2} {
-			var expectedQueryResult = pb.Memory{
+			expectedQueryResult := pb.Memory{
 				Brand: expectedQueryResults[id].Brand,
 				Size:  expectedQueryResults[id].Size,
 				Speed: expectedQueryResults[id].Speed,
 				Type:  expectedQueryResults[id].Type,
 			}
-			var actualQueryResult = pb.Memory{
+			actualQueryResult := pb.Memory{
 				Brand: actualQueryResults[id].Brand,
 				Size:  actualQueryResults[id].Size,
 				Speed: actualQueryResults[id].Speed,
@@ -385,25 +382,25 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 	}
 
 	{
-		//Check if you can find all memory records when passing a pointer to map of strings to pointers to structs
-		var actualQueryResults = make(map[string]*pb.Memory)
+		// Check if you can find all memory records when passing a pointer to map of strings to pointers to structs
+		actualQueryResults := make(map[string]*pb.Memory)
 		metadataMap, err := p.FindAllAsMap(ctx, actualQueryResults)
 		assert.NoError(err)
 		assert.Len(actualQueryResults, 2)
 		assert.Len(metadataMap, 2)
 
-		var expectedQueryResults = make(map[string]*pb.Memory)
+		expectedQueryResults := make(map[string]*pb.Memory)
 		expectedQueryResults[P1] = &memmsg1
 		expectedQueryResults[P2] = &memmsg2
 
 		for _, id := range []string{P1, P2} {
-			var expectedQueryResult, actualQueryResult = expectedQueryResults[id], actualQueryResults[id]
+			expectedQueryResult, actualQueryResult := expectedQueryResults[id], actualQueryResults[id]
 			assert.Equal(expectedQueryResult.String(), actualQueryResult.String())
 		}
 	}
 
 	{
-		//Check if you can find all CPU records when passing a pointer to slice of structs
+		// Check if you can find all CPU records when passing a pointer to slice of structs
 		var actualQueryResults CPUSlice = make([]pb.CPU, 0)
 		metadataMap, err := p.FindAll(ctx, &actualQueryResults)
 		assert.NoError(err)
@@ -416,7 +413,7 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 	}
 
 	{
-		//Check if you can find all CPU records when passing a pointer to slice of pointers to structs
+		// Check if you can find all CPU records when passing a pointer to slice of pointers to structs
 		var actualQueryResults CPUPtrSlice = make([]*pb.CPU, 0)
 		metadataMap, err := p.FindAll(ctx, &actualQueryResults)
 		assert.NoError(err)
@@ -429,14 +426,14 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 	}
 
 	{
-		//Check if you can find all CPU records when passing a pointer to map of strings to structs
-		var actualQueryResults = make(map[string]pb.CPU)
+		// Check if you can find all CPU records when passing a pointer to map of strings to structs
+		actualQueryResults := make(map[string]pb.CPU)
 		metadataMap, err := p.FindAllAsMap(ctx, actualQueryResults)
 		assert.NoError(err)
 		assert.Len(actualQueryResults, 2)
 		assert.Len(metadataMap, 2)
 
-		var expectedQueryResults = make(map[string]pb.CPU)
+		expectedQueryResults := make(map[string]pb.CPU)
 		expectedQueryResults[P1] = pb.CPU{
 			Brand:         cpumsg1.Brand,
 			Name:          cpumsg1.Name,
@@ -455,7 +452,7 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 		}
 
 		for _, id := range []string{P1, P2} {
-			var expectedQueryResult = pb.CPU{
+			expectedQueryResult := pb.CPU{
 				Brand:         expectedQueryResults[id].Brand,
 				Name:          expectedQueryResults[id].Name,
 				NumberCores:   expectedQueryResults[id].NumberCores,
@@ -463,7 +460,7 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 				MinGhz:        expectedQueryResults[id].MinGhz,
 				MaxGhz:        expectedQueryResults[id].MaxGhz,
 			}
-			var actualQueryResult = pb.CPU{
+			actualQueryResult := pb.CPU{
 				Brand:         actualQueryResults[id].Brand,
 				Name:          actualQueryResults[id].Name,
 				NumberCores:   actualQueryResults[id].NumberCores,
@@ -476,19 +473,19 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 	}
 
 	{
-		//Check if you can find all CPU records when passing a pointer to map of strings to pointers to structs
-		var actualQueryResults = make(map[string]*pb.CPU)
+		// Check if you can find all CPU records when passing a pointer to map of strings to pointers to structs
+		actualQueryResults := make(map[string]*pb.CPU)
 		metadataMap, err := p.FindAllAsMap(ctx, actualQueryResults)
 		assert.NoError(err)
 		assert.Len(actualQueryResults, 2)
 		assert.Len(metadataMap, 2)
 
-		var expectedQueryResults = make(map[string]*pb.CPU)
+		expectedQueryResults := make(map[string]*pb.CPU)
 		expectedQueryResults[P1] = &cpumsg1
 		expectedQueryResults[P2] = &cpumsg2
 
 		for _, id := range []string{P1, P2} {
-			var expectedQueryResult, actualQueryResult = expectedQueryResults[id], actualQueryResults[id]
+			expectedQueryResult, actualQueryResult := expectedQueryResults[id], actualQueryResults[id]
 			assert.Equal(expectedQueryResult.String(), actualQueryResult.String())
 		}
 	}
@@ -507,14 +504,13 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 		err := p.DropTables(protoMsgs...)
 		assert.NoError(err)
 
-		var cpuQueryResults = make(map[string]*pb.CPU)
+		cpuQueryResults := make(map[string]*pb.CPU)
 		_, err = p.FindAllAsMap(ctx, cpuQueryResults)
 		assert.ErrorIs(err, ErrorExecutingSqlStmt)
 
-		var memoryQueryResults = make([]*pb.Memory, 0)
+		memoryQueryResults := make([]*pb.Memory, 0)
 		_, err = p.FindAll(ctx, &memoryQueryResults)
 		assert.ErrorIs(err, ErrorExecutingSqlStmt)
-
 	}
 }
 
@@ -523,7 +519,7 @@ func TestProtoStoreInDbCrud(t *testing.T) {
 	testProtoStoreCrud(t, pepsiAdminCtx, false)
 }
 
-// Same as TestProtoStoreInDbCrud, but uses Upsert instead of Insert or Update
+// Same as TestProtoStoreInDbCrud, but uses Upsert instead of Insert or Update.
 func TestProtoStoreInDbCrudUpsert(t *testing.T) {
 	setupDbContext(t)
 	testProtoStoreCrud(t, pepsiAdminCtx, true)
@@ -534,7 +530,7 @@ func TestProtoStoreInMemoryCrud(t *testing.T) {
 	testProtoStoreCrud(t, cokeAdminCtx, false)
 }
 
-// Same as TestProtoStoreInMemoryCrudm but uses Upsert instead of Insert or Update
+// Same as TestProtoStoreInMemoryCrudm but uses Upsert instead of Insert or Update.
 func TestProtoStoreInMemoryCrudUpsert(t *testing.T) {
 	setupInMemoryContext(t)
 	testProtoStoreCrud(t, cokeAdminCtx, true)
@@ -552,8 +548,8 @@ func testProtoStoreCrud(t *testing.T, ctx context.Context, useUpsert bool) {
 	var rowsAffected int64
 	var metadata1, metadata2, metadata3 Metadata
 
-	//Insert Protobuf record
-	var cpumsg1 = pb.CPU{}
+	// Insert Protobuf record
+	cpumsg1 := pb.CPU{}
 	_ = faker.FakeData(&cpumsg1)
 	if useUpsert {
 		rowsAffected, _, err = p.UpsertWithMetadata(ctx, P4, &cpumsg1, Metadata{Revision: 1})
@@ -563,19 +559,19 @@ func testProtoStoreCrud(t *testing.T, ctx context.Context, useUpsert bool) {
 	assert.NoError(err, "Failed to insert a Protobuf message into ProtoStore")
 	assert.Equal(int64(1), rowsAffected)
 
-	//Query Protobuf record
-	var cpumsg2 = pb.CPU{}
+	// Query Protobuf record
+	cpumsg2 := pb.CPU{}
 	err = p.FindById(ctx, P4, &cpumsg2, &metadata1)
 	assert.NoError(err, "Failed to find a Protobuf message in ProtoStore")
 	assert.Equal(cpumsg1.String(), cpumsg2.String())
-	if DataStore == &relationalDb { //Only check this for Postgres-backed ProtoStore
+	if DataStore == &relationalDb { // Only check this for Postgres-backed ProtoStore
 		revision, err := p.GetRevision(ctx, P4, &pb.CPU{})
 		assert.NoError(err)
 		assert.Equal(int64(1), revision)
 	}
 
-	//Update Protobuf record (with metadata provided explicitly)
-	var cpumsg3 = pb.CPU{}
+	// Update Protobuf record (with metadata provided explicitly)
+	cpumsg3 := pb.CPU{}
 	_ = faker.FakeData(&cpumsg3)
 	if useUpsert {
 		rowsAffected, metadata2, err = p.UpsertWithMetadata(ctx, P4, &cpumsg3, metadata1)
@@ -584,27 +580,27 @@ func testProtoStoreCrud(t *testing.T, ctx context.Context, useUpsert bool) {
 	}
 	assert.NoError(err, "Failed to update a Protobuf message in ProtoStore")
 	assert.EqualValues(1, rowsAffected)
-	if DataStore == &relationalDb { //Only check this for Postgres-backed ProtoStore
+	if DataStore == &relationalDb { // Only check this for Postgres-backed ProtoStore
 		assert.EqualValues(metadata1.Revision+1, metadata2.Revision, "Revision did not increment by 1 after an update")
 		revision, err := p.GetRevision(ctx, P4, &pb.CPU{})
 		assert.NoError(err)
 		assert.Equal(metadata1.Revision+1, revision)
 	}
 
-	//Query updated Protobuf record
-	var cpumsg4 = pb.CPU{}
+	// Query updated Protobuf record
+	cpumsg4 := pb.CPU{}
 	err = p.FindById(ctx, P4, &cpumsg4, &metadata2)
 	assert.NoError(err, "Failed to find the updated Protobuf message in ProtoStore")
 	assert.Equal(cpumsg3.String(), cpumsg4.String())
-	if DataStore == &relationalDb { //Only check this for Postgres-backed ProtoStore
+	if DataStore == &relationalDb { // Only check this for Postgres-backed ProtoStore
 		assert.EqualValues(metadata1.Revision+1, metadata2.Revision, "Revision did not increment by 1 after an update")
 		revision, err := p.GetRevision(ctx, P4, &pb.CPU{})
 		assert.NoError(err)
 		assert.Equal(metadata1.Revision+1, revision)
 	}
 
-	//Update Protobuf record (without metadata)
-	var cpumsg5 = pb.CPU{}
+	// Update Protobuf record (without metadata)
+	cpumsg5 := pb.CPU{}
 	_ = faker.FakeData(&cpumsg5)
 	cpumsg5String := cpumsg5.String()
 	if useUpsert {
@@ -616,19 +612,19 @@ func testProtoStoreCrud(t *testing.T, ctx context.Context, useUpsert bool) {
 	assert.EqualValues(1, rowsAffected)
 	assert.NotEqual(cpumsg4.String(), cpumsg5.String())
 	assert.Equal(cpumsg5String, cpumsg5.String())
-	if DataStore == &relationalDb { //Only check this for Postgres-backed ProtoStore
+	if DataStore == &relationalDb { // Only check this for Postgres-backed ProtoStore
 		assert.EqualValues(metadata2.Revision+1, metadata3.Revision, "Revision did not increment by 1 after an update")
 		revision, err := p.GetRevision(ctx, P4, &pb.CPU{})
 		assert.NoError(err)
 		assert.Equal(metadata2.Revision+1, revision)
 	}
 
-	//Query all Protobuf records
-	var allCpus = make([]pb.CPU, 0)
+	// Query all Protobuf records
+	allCpus := make([]pb.CPU, 0)
 	metadataMap, err := p.FindAll(ctx, &allCpus)
 	assert.NoError(err)
 	assert.Len(allCpus, 1)
-	if DataStore == &relationalDb { //Only check this for Postgres-backed ProtoStore
+	if DataStore == &relationalDb { // Only check this for Postgres-backed ProtoStore
 		assert.Len(metadataMap, 1)
 		assert.Contains(metadataMap, P4)
 		assert.EqualValues(metadata2.Revision+1, metadataMap[P4].Revision, "Revision did not increment by 1 after an update")
@@ -637,10 +633,10 @@ func testProtoStoreCrud(t *testing.T, ctx context.Context, useUpsert bool) {
 		assert.EqualValues(metadata2.Revision+1, revision, "Revision did not increment by 1 after an update")
 	}
 
-	var memmsg1 = pb.Memory{}
+	memmsg1 := pb.Memory{}
 	_ = faker.FakeData(&memmsg1)
 	if useUpsert {
-		//rowsAffected, _, err = p.UpsertWithMetadata(ctx, P4, &memmsg1, Metadata{Revision: 1})
+		// rowsAffected, _, err = p.UpsertWithMetadata(ctx, P4, &memmsg1, Metadata{Revision: 1})
 		rowsAffected, _, err = p.Upsert(ctx, P4, &memmsg1)
 	} else {
 		rowsAffected, _, err = p.Insert(ctx, P4, &memmsg1)
@@ -648,11 +644,11 @@ func testProtoStoreCrud(t *testing.T, ctx context.Context, useUpsert bool) {
 	assert.NoError(err, "Failed to insert a Protobuf message into ProtoStore")
 	assert.Equal(int64(1), rowsAffected)
 
-	var memmsg2 = pb.Memory{}
+	memmsg2 := pb.Memory{}
 	err = p.FindById(ctx, P4, &memmsg2, &metadata1)
 	assert.NoError(err, "Failed to find a Protobuf message in ProtoStore")
 	assert.Equal(memmsg1.String(), memmsg2.String())
-	if DataStore == &relationalDb { //Only check this for Postgres-backed ProtoStore
+	if DataStore == &relationalDb { // Only check this for Postgres-backed ProtoStore
 		assert.Equal(P4, metadata1.Id)
 		assert.Equal(int64(1), metadata1.Revision)
 		revision, err := p.GetRevision(ctx, P4, &pb.Memory{})
@@ -660,7 +656,7 @@ func testProtoStoreCrud(t *testing.T, ctx context.Context, useUpsert bool) {
 		assert.Equal(int64(1), revision)
 	}
 
-	var memmsg3 = pb.Memory{}
+	memmsg3 := pb.Memory{}
 	_ = faker.FakeData(&memmsg3)
 	if useUpsert {
 		rowsAffected, _, err = p.UpsertWithMetadata(ctx, P4, &memmsg3, metadata1)
@@ -670,7 +666,7 @@ func testProtoStoreCrud(t *testing.T, ctx context.Context, useUpsert bool) {
 	assert.NoError(err, "Failed to update a Protobuf message in ProtoStore")
 	assert.EqualValues(1, rowsAffected)
 
-	var memmsg4 = pb.Memory{}
+	memmsg4 := pb.Memory{}
 	err = p.FindById(ctx, P4, &memmsg4, nil)
 	assert.NoError(err, "Failed to find an updated Protobuf message in ProtoStore")
 	assert.Equal(memmsg3.String(), memmsg4.String())
@@ -683,8 +679,8 @@ func testProtoStoreCrud(t *testing.T, ctx context.Context, useUpsert bool) {
 	assert.NoError(err, "Deleting a non-existent Protobuf message produced an error. DeleteById() might be not idempotent.")
 	assert.EqualValues(0, rowsAffected)
 
-	//Delete CPU message with an ID of P4. Memory message with an ID of P4 must remain intact
-	var cpumsg6 = pb.CPU{}
+	// Delete CPU message with an ID of P4. Memory message with an ID of P4 must remain intact
+	cpumsg6 := pb.CPU{}
 	err = p.FindById(ctx, P4, &cpumsg6, nil)
 	assert.ErrorIs(err, RecordNotFoundError)
 	assert.Equal("", cpumsg6.String(), "Found a Protobuf message that was supposed to be deleted")
@@ -701,7 +697,7 @@ func testProtoStoreCrud(t *testing.T, ctx context.Context, useUpsert bool) {
 	assert.NoError(err, "Deleting a non-existent Protobuf message produced an error. DeleteById() might be not idempotent.")
 	assert.EqualValues(0, rowsAffected)
 
-	var memmsg5 = pb.Memory{}
+	memmsg5 := pb.Memory{}
 	err = p.FindById(ctx, P4, &memmsg5, nil)
 	assert.ErrorIs(err, RecordNotFoundError)
 	assert.Equal("", memmsg5.String(), "Found a Protobuf message that was supposed to be deleted")
@@ -714,17 +710,17 @@ func TestProtoStoreInDbMultitenancy(t *testing.T) {
 	assert := assert.New(t)
 
 	var p ProtoStore = GetProtoStore()
-	var cpumsg1 = pb.CPU{}
+	cpumsg1 := pb.CPU{}
 	_ = faker.FakeData(&cpumsg1)
-	rowsAffected, md, err := p.Insert(pepsiAdminCtx, cpumsg1.Name, &cpumsg1) //Pepsi inserts a record into Protostore
+	rowsAffected, md, err := p.Insert(pepsiAdminCtx, cpumsg1.Name, &cpumsg1) // Pepsi inserts a record into Protostore
 	assert.NoError(err)
 	assert.Equal(int64(1), rowsAffected)
 	assert.Equal(cpumsg1.Name, md.Id)
 	assert.Equal(int64(1), md.Revision)
 
-	var queryResult = pb.CPU{}
-	err = p.FindById(cokeAdminCtx, cpumsg1.Name, &queryResult, nil) //Coke tries to read Pepsi's Protobuf message
-	assert.ErrorIs(err, RecordNotFoundError)                        //Coke won't be able to see that record due to RLS
+	queryResult := pb.CPU{}
+	err = p.FindById(cokeAdminCtx, cpumsg1.Name, &queryResult, nil) // Coke tries to read Pepsi's Protobuf message
+	assert.ErrorIs(err, RecordNotFoundError)                        // Coke won't be able to see that record due to RLS
 	assert.Empty(queryResult.GetName(), "Coke user found a record belonging to Pepsi tenant")
 }
 

--- a/data-access-layer/datastore/record.go
+++ b/data-access-layer/datastore/record.go
@@ -29,7 +29,7 @@ type Record interface {
 }
 
 func GetRecordInstanceFromSlice(x interface{}) Record {
-	var sliceType = reflect.TypeOf(x)
+	sliceType := reflect.TypeOf(x)
 	if sliceType.Kind() == reflect.Ptr {
 		sliceType = sliceType.Elem()
 	}
@@ -40,7 +40,7 @@ func GetRecordInstanceFromSlice(x interface{}) Record {
 	*/
 	var areSliceElemPtrs bool = sliceType.Elem().Kind() == reflect.Ptr
 
-	var sliceElemType = sliceType.Elem()
+	sliceElemType := sliceType.Elem()
 	if sliceElemType.Kind() == reflect.Ptr {
 		sliceElemType = sliceElemType.Elem()
 	}

--- a/data-access-layer/datastore/sql_struct.go
+++ b/data-access-layer/datastore/sql_struct.go
@@ -32,16 +32,16 @@ Library processing all the golang tags in the struct into SQL domain
 */
 
 const (
-	// Golang Tags
+	// Golang Tags.
 	TAG_DB_COLUMN = "db_column"
 	TAG_PRIMARY   = "primary_key"
 	TAG_INDEX     = "db_index"
 
-	// SQL Columns
+	// SQL Columns.
 	ORG_ID_COLUMN_NAME   = "org_id"
 	REVISION_COLUMN_NAME = "_revision"
 
-	// Messages
+	// Messages.
 	REVISION_OUTDATED_MSG = "Invalid update - outdated "
 )
 
@@ -52,21 +52,21 @@ type DatabaseColumn struct {
 	index    bool
 }
 
-// Maps a DB table name to its columns
+// Maps a DB table name to its columns.
 var databaseColumns map[string]*[]DatabaseColumn = make(map[string]*[]DatabaseColumn)
 
-// Maps a DB table name to booleans showing if the table is multitenant
+// Maps a DB table name to booleans showing if the table is multitenant.
 var multitenancyMap map[string]bool = make(map[string]bool)
 
-// Maps a DB table name to the names of DB columns that comprise the primary key
+// Maps a DB table name to the names of DB columns that comprise the primary key.
 var primaryKeyMap map[string][]string = make(map[string][]string)
 
-// Maps DB table name to boolean showing if the table is concurrent with _revision column
+// Maps DB table name to boolean showing if the table is concurrent with _revision column.
 var revisionSupportMap map[string]bool = make(map[string]bool)
 
 /*
 Checks if revisioning is supported in the given table (if
-the struct contains a field with tag "db_column" equal to "_revision")
+the struct contains a field with tag "db_column" equal to "_revision").
 */
 func isRevisioningSupported(tableName string, x Record) bool {
 	if _, ok := revisionSupportMap[tableName]; !ok {
@@ -93,7 +93,7 @@ func IsMultitenant(x Record, tableNames ...string) bool {
 }
 
 /*
-Returns columns comprising a primary key of a table
+Returns columns comprising a primary key of a table.
 */
 func getPrimaryKey(tableName string, x Record) []string {
 	if _, ok := primaryKeyMap[tableName]; !ok {
@@ -164,7 +164,7 @@ func getDatabaseColumnDatatype(structField reflect.StructField) string {
 }
 
 /*
-Wraps IF NOT EXISTS around the given statement
+Wraps IF NOT EXISTS around the given statement.
 */
 func addIfNotExists(stmt, cond string) string {
 	var wrapper strings.Builder
@@ -193,7 +193,7 @@ func addIfExists(stmt, cond string) string {
 Returns a SQL statement that sets a Postgres config. parameter
 settingName - parameter name
 settingValue - parameter value
-isLocal - if true, the new value for the parameter will apply only for current transaction; otherwise, the new value will be visible outside this transaction
+isLocal - if true, the new value for the parameter will apply only for current transaction; otherwise, the new value will be visible outside this transaction.
 */
 func getSetConfigStmt(settingName, settingValue string, isLocal bool) string {
 	var stmt strings.Builder
@@ -209,9 +209,9 @@ func getSetConfigStmt(settingName, settingValue string, isLocal bool) string {
 }
 
 /*
-Returns a SQL statement that enables row-level security in a DB table
+Returns a SQL statement that enables row-level security in a DB table.
 */
-func getEnableRLSStmt(tableName string, x Record) string {
+func getEnableRLSStmt(tableName string, _ Record) string {
 	var stmt strings.Builder
 	stmt.WriteString("ALTER TABLE ")
 	stmt.WriteString(tableName)
@@ -221,7 +221,7 @@ func getEnableRLSStmt(tableName string, x Record) string {
 }
 
 /*
-Returns a SQL statement that creates a DB user with the given specs, if it does not exist yet
+Returns a SQL statement that creates a DB user with the given specs, if it does not exist yet.
 */
 func getCreateUserStmt(username DbRole, password string) string {
 	var findRoleQuery, createUserStmt strings.Builder
@@ -241,7 +241,7 @@ func getCreateUserStmt(username DbRole, password string) string {
 	return stmt
 }
 
-func getGrantPrivilegesStmt(tableName string, x Record, username DbRole, commands []string) string {
+func getGrantPrivilegesStmt(tableName string, _ Record, username DbRole, commands []string) string {
 	var stmt strings.Builder
 	stmt.WriteString("GRANT ")
 	stmt.WriteString(strings.Join(commands, ", "))
@@ -255,9 +255,9 @@ func getGrantPrivilegesStmt(tableName string, x Record, username DbRole, command
 }
 
 /*
-Returns a SQL statement that creates an RLS-policy with the given specs, if it does not exist yet
+Returns a SQL statement that creates an RLS-policy with the given specs, if it does not exist yet.
 */
-func getCreatePolicyStmt(tableName string, x Record, userSpecs dbUserSpecs) string {
+func getCreatePolicyStmt(tableName string, _ Record, userSpecs dbUserSpecs) string {
 	if userSpecs.existingRowsCond == "" || userSpecs.newRowsCond == "" {
 		panic(userSpecs)
 	}
@@ -291,7 +291,7 @@ Validates that the given struct satisfied the following preconditions:
 - Each field is exported
 - Each field has a tag for DB column name with a unique value
 - At least one field has a tag marking it as a primary key
-- Only supported data types are used in the struct
+- Only supported data types are used in the struct.
 */
 func validateStruct(x Record) {
 	structValue := reflect.ValueOf(x)
@@ -301,9 +301,9 @@ func validateStruct(x Record) {
 	structType := structValue.Type()
 
 	// Each field in the struct has to be exported, have a 'db_column' tag, be of one of the supported types
-	//The struct has to have a primary key consisting of one field
+	// The struct has to have a primary key consisting of one field
 	numPrimaryKeyTags := 0
-	var dbColumnNamesSet = make(map[string]struct{}) // Set that will contain the [unique] names of DB columns'
+	dbColumnNamesSet := make(map[string]struct{}) // Set that will contain the [unique] names of DB columns'
 	for i := 0; i < structType.NumField(); i++ {
 		dbColumnNamesSet[structType.Field(i).Tag.Get(TAG_DB_COLUMN)] = struct{}{}
 
@@ -374,15 +374,15 @@ func GetTableName(x interface{}) string {
 }
 
 /*
-Extracts name of a struct comprising the input slice
+Extracts name of a struct comprising the input slice.
 */
 func GetTableNameFromSlice(x interface{}) string {
-	var sliceType = reflect.TypeOf(x)
+	sliceType := reflect.TypeOf(x)
 	if sliceType.Kind() == reflect.Ptr {
 		sliceType = sliceType.Elem()
 	}
 
-	var sliceElemType = sliceType.Elem()
+	sliceElemType := sliceType.Elem()
 	if sliceElemType.Kind() == reflect.Ptr {
 		sliceElemType = sliceElemType.Elem()
 	}
@@ -391,7 +391,7 @@ func GetTableNameFromSlice(x interface{}) string {
 }
 
 /*
-Generates RLS-policy name based on database role/user and table name
+Generates RLS-policy name based on database role/user and table name.
 */
 func GetRlsPolicyName(username DbRole, tableName string) string {
 	policyName := strings.ToLower(string(username) + "_" + tableName + "_policy")
@@ -408,7 +408,7 @@ func getCreateTableStmt(tableName string, x Record) string {
 	validateStruct(x)
 
 	var stmt strings.Builder
-	var primaryKeys = make([]string, 0, 4 /* init. capacity */)
+	primaryKeys := make([]string, 0, 4 /* init. capacity */)
 	stmt.WriteString("CREATE TABLE IF NOT EXISTS ")
 	stmt.WriteString(tableName)
 	stmt.WriteString(" (\n")
@@ -500,7 +500,7 @@ func getTruncateTableStmt(tableName string) string {
 	return addIfExists(truncateTableStmt.String(), findTableQuery.String())
 }
 
-// Returns a DROP TABLE statement
+// Returns a DROP TABLE statement.
 func getDropTableStmt(tableName string) string {
 	stmt := fmt.Sprintf("DROP TABLE IF EXISTS %s ;", tableName)
 	logger.Infof("Executing Statement %s", stmt)
@@ -508,9 +508,9 @@ func getDropTableStmt(tableName string) string {
 }
 
 // Returns a SELECT statement with no WHERE condition(s) and arguments to be used in place of placeholders.
-// Considers non-empty fields of x as filters for WHERE clause
+// Considers non-empty fields of x as filters for WHERE clause.
 func getSelectStmt(tableName string, x Record) (string, []interface{}) {
-	var placeholderIndex = 1
+	placeholderIndex := 1
 	structValue := reflect.ValueOf(x)
 	if structValue.Kind() == reflect.Ptr {
 		structValue = structValue.Elem()
@@ -543,9 +543,8 @@ func getSelectStmt(tableName string, x Record) (string, []interface{}) {
 	return query.String(), args
 }
 
-// Returns a SELECT statement with a single WHERE condition for the primary key
+// Returns a SELECT statement with a single WHERE condition for the primary key.
 func getSelectSingleStmt(tableName string, x Record) string {
-
 	placeholderIndex := 1
 	var query strings.Builder
 	query.WriteString("SELECT ")
@@ -569,7 +568,6 @@ func getSelectSingleStmt(tableName string, x Record) string {
 }
 
 func getSelectJoinStmt(table1Name string, table2Name string, record1 Record, record2 Record, record2JoinOnColumn string, limit int) string {
-
 	var query strings.Builder
 	table1Columns := *getColumnNames(table1Name, record1)
 	table2Columns := *getColumnNames(table2Name, record2)
@@ -747,7 +745,6 @@ func getUpsertStmt(tableName string, x Record) (string, []interface{}) {
 
 // Returns a DELETE statement.
 func getDeleteStmt(tableName string, x Record) string {
-
 	placeholderIndex := 1
 	var stmt strings.Builder
 	stmt.WriteString("DELETE FROM ")

--- a/data-access-layer/datastore/sql_struct_test.go
+++ b/data-access-layer/datastore/sql_struct_test.go
@@ -30,16 +30,16 @@ func TestSelectStmtGeneration(t *testing.T) {
 	myApp, _, _ := prepareInput()
 	tableName := GetTableName(myApp)
 
-	//Since myApp is non-empty, the generated SELECT statement must contain placeholders in WHERE clause
+	// Since myApp is non-empty, the generated SELECT statement must contain placeholders in WHERE clause
 	stmt, args := getSelectStmt(tableName, myApp)
 	assert.Equal(len(args), strings.Count(stmt, "$"))
 
 	assert.Contains(stmt, "WHERE")
-	//SELECT stmt must contain as many placeholders ('$') as there are non-empty fields in myApp
+	// SELECT stmt must contain as many placeholders ('$') as there are non-empty fields in myApp
 	assert.Equal(3, strings.Count(stmt, "$"))
 	assert.NotEmpty(args)
 
-	//Since the record passed is empty, the generated SELECT statement must NOT contain placeholders
+	// Since the record passed is empty, the generated SELECT statement must NOT contain placeholders
 	stmt, args = getSelectStmt(tableName, app{})
 	assert.NotContains(stmt, "$")
 	assert.NotContains(stmt, "WHERE")
@@ -53,7 +53,7 @@ func TestSelectSingleStmtGeneration(t *testing.T) {
 
 	stmt := getSelectSingleStmt(tableName, myApp)
 	assert.Contains(stmt, "WHERE")
-	//SELECT stmt must contain as many placeholders ('$') as there columns in the primary key of myApp
+	// SELECT stmt must contain as many placeholders ('$') as there columns in the primary key of myApp
 	assert.Equal(2, strings.Count(stmt, "$"))
 }
 
@@ -65,9 +65,8 @@ func TestDeleteStmtGeneration(t *testing.T) {
 	stmt := getDeleteStmt(tableName, myApp)
 	assert.Contains(stmt, "WHERE")
 	primaryKey := getPrimaryKey(tableName, myApp)
-	//DELETE stmt must contain as many placeholders ('$') as there are columns in the primary key of myApp
+	// DELETE stmt must contain as many placeholders ('$') as there are columns in the primary key of myApp
 	assert.Equal(len(primaryKey), strings.Count(stmt, "$"))
-
 }
 
 func TestInsertStmtGeneration(t *testing.T) {
@@ -80,7 +79,7 @@ func TestInsertStmtGeneration(t *testing.T) {
 
 	assert.Contains(stmt, "VALUES")
 	assert.Equal(3, len(args))
-	//INSERT stmt must contain as many placeholders ('$') as there are columns in myApp
+	// INSERT stmt must contain as many placeholders ('$') as there are columns in myApp
 	assert.Equal(3, strings.Count(stmt, "$"))
 }
 
@@ -94,11 +93,11 @@ func TestUpdateStmtGeneration(t *testing.T) {
 
 	assert.Contains(stmt, "WHERE")
 	assert.Equal(3, len(args))
-	//UPDATE stmt must contain as many placeholders ('$') in the SET clause as there are non-primary key columns
+	// UPDATE stmt must contain as many placeholders ('$') in the SET clause as there are non-primary key columns
 	setClause := stmt[strings.Index(stmt, "SET"):strings.Index(stmt, "WHERE")]
 	assert.Equal(1, strings.Count(setClause, "$"))
 
-	//UPDATE stmt must contain as many placeholders ('$') in the WHERE clause as there are columns in the primary key of myApp
+	// UPDATE stmt must contain as many placeholders ('$') in the WHERE clause as there are columns in the primary key of myApp
 	whereClause := stmt[strings.Index(stmt, "WHERE"):]
 	assert.Equal(2, strings.Count(whereClause, "$"))
 }
@@ -129,7 +128,7 @@ func TestUpsertStmtGeneration(t *testing.T) {
 }
 
 /*
-Tests whether all the functions generating SQL statements can accept both structs and pointers to structs
+Tests whether all the functions generating SQL statements can accept both structs and pointers to structs.
 */
 func TestPassingPointersToStructs(t *testing.T) {
 	assert := assert.New(t)
@@ -153,7 +152,7 @@ func TestPassingPointersToStructs(t *testing.T) {
 }
 
 /*
-Tests whether primary key is correct stored in an in-memory cache
+Tests whether primary key is correct stored in an in-memory cache.
 */
 func TestGetPrimaryKey(t *testing.T) {
 	assert := assert.New(t)
@@ -165,7 +164,7 @@ func TestGetPrimaryKey(t *testing.T) {
 }
 
 /*
-Checks if table name can be extracted from struct/slice of structs using utility methods
+Checks if table name can be extracted from struct/slice of structs using utility methods.
 */
 func TestGettingTableName(t *testing.T) {
 	assert := assert.New(t)
@@ -173,7 +172,7 @@ func TestGettingTableName(t *testing.T) {
 	assert.Equal("\"appUser\"", GetTableName(appUser{}))
 	assert.Equal("\"appUser\"", GetTableName(&appUser{}))
 
-	//Reserved keyword
+	// Reserved keyword
 	assert.Equal("\"group\"", GetTableName(group{}))
 
 	assert.Equal("\"appUser\"", GetTableNameFromSlice([]appUser{}))

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -156,16 +156,16 @@ const (
 
 ```go
 const (
-    // DB Runtime Parameters
+    // DB Runtime Parameters.
     DB_CONFIG_ORG_ID = "multitenant.orgId" // Name of Postgres run-time config. parameter that will store current user's org. ID
 
-    // DB Roles
+    // DB Roles.
     TENANT_READER DbRole = "tenant_reader"
     TENANT_WRITER DbRole = "tenant_writer"
     READER        DbRole = "reader"
     WRITER        DbRole = "writer"
 
-    // Env. variable names
+    // Env. variable names.
     DB_NAME_ENV_VAR           = "DB_NAME"
     DB_PORT_ENV_VAR           = "DB_PORT"
     DB_HOST_ENV_VAR           = "DB_HOST"
@@ -194,16 +194,16 @@ const (
 
 ```go
 const (
-    // Golang Tags
+    // Golang Tags.
     TAG_DB_COLUMN = "db_column"
     TAG_PRIMARY   = "primary_key"
     TAG_INDEX     = "db_index"
 
-    // SQL Columns
+    // SQL Columns.
     ORG_ID_COLUMN_NAME   = "org_id"
     REVISION_COLUMN_NAME = "_revision"
 
-    // Messages
+    // Messages.
     REVISION_OUTDATED_MSG = "Invalid update - outdated "
 )
 ```
@@ -213,6 +213,14 @@ const GLOBAL_DEFAULT_ORG_ID = "_GlobalDefaultOrg"
 ```
 
 ## Variables
+
+```go
+var (
+    DataStore  dataStore           = &relationalDb
+    Helper     DataStoreHelper     = &relationalDb
+    TestHelper DataStoreTestHelper = &relationalDb
+)
+```
 
 ```go
 var (
@@ -256,7 +264,7 @@ func FromBytes(bytes []byte, message proto.Message) error
 func GetRlsPolicyName(username DbRole, tableName string) string
 ```
 
-Generates RLS\-policy name based on database role/user and table name
+Generates RLS\-policy name based on database role/user and table name.
 
 ## func [GetTableName](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/sql_struct.go#L363>)
 
@@ -272,7 +280,7 @@ Extracts struct's name, which will serve as DB table name, using reflection.
 func GetTableNameFromSlice(x interface{}) string
 ```
 
-Extracts name of a struct comprising the input slice
+Extracts name of a struct comprising the input slice.
 
 ## func [IsMultitenant](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/sql_struct.go#L81>)
 
@@ -323,17 +331,13 @@ type DataStoreHelper interface {
 }
 ```
 
-```go
-var Helper DataStoreHelper = &relationalDb
-```
-
-### func [DatastoreHelperInDatabase](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/datastore.go#L92>)
+### func [DatastoreHelperInDatabase](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/datastore.go#L94>)
 
 ```go
 func DatastoreHelperInDatabase() DataStoreHelper
 ```
 
-### func [DatastoreHelperInMemory](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/datastore.go#L86>)
+### func [DatastoreHelperInMemory](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/datastore.go#L88>)
 
 ```go
 func DatastoreHelperInMemory() DataStoreHelper
@@ -349,10 +353,6 @@ type DataStoreTestHelper interface {
 }
 ```
 
-```go
-var TestHelper DataStoreTestHelper = &relationalDb
-```
-
 ## type [DatabaseColumn](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/sql_struct.go#L48-L53>)
 
 ```go
@@ -361,7 +361,7 @@ type DatabaseColumn struct {
 }
 ```
 
-## type [DbError](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L72-L76>)
+## type [DbError](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L73-L77>)
 
 ```go
 type DbError struct {
@@ -369,49 +369,49 @@ type DbError struct {
 }
 ```
 
-### func \(\*DbError\) [Error](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L78>)
+### func \(\*DbError\) [Error](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L79>)
 
 ```go
 func (e *DbError) Error() string
 ```
 
-### func \(\*DbError\) [Is](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L89>)
+### func \(\*DbError\) [Is](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L90>)
 
 ```go
 func (e *DbError) Is(target error) bool
 ```
 
-### func \(\*DbError\) [Unwrap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L97>)
+### func \(\*DbError\) [Unwrap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L98>)
 
 ```go
 func (e *DbError) Unwrap() error
 ```
 
-### func \(\*DbError\) [With](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L109>)
+### func \(\*DbError\) [With](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L110>)
 
 ```go
 func (e *DbError) With(msg string) *DbError
 ```
 
-### func \(\*DbError\) [WithContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L117>)
+### func \(\*DbError\) [WithContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L118>)
 
 ```go
 func (e *DbError) WithContext(ctx context.Context) *DbError
 ```
 
-### func \(\*DbError\) [WithMap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L141>)
+### func \(\*DbError\) [WithMap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L142>)
 
 ```go
 func (e *DbError) WithMap(kvMap map[ErrorContextKey]string) *DbError
 ```
 
-### func \(\*DbError\) [WithValue](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L129>)
+### func \(\*DbError\) [WithValue](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L130>)
 
 ```go
 func (e *DbError) WithValue(key ErrorContextKey, value string) *DbError
 ```
 
-### func \(\*DbError\) [Wrap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L101>)
+### func \(\*DbError\) [Wrap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L102>)
 
 ```go
 func (e *DbError) Wrap(err error) *DbError
@@ -419,7 +419,7 @@ func (e *DbError) Wrap(err error) *DbError
 
 ## type [DbRole](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L51>)
 
-Database roles/users
+Database roles/users.
 
 ```go
 type DbRole string
@@ -451,9 +451,9 @@ func (a DbRoleSlice) Less(i, j int) bool
 
 Returns true if the first role has fewer permissions than the second role, and true if the two roles are the same or the second role has more permissions. A reader role is always considered to have fewer permissions than a writer role. and a tenant\-specific reader/writer role is always considered to have fewer permissions than a non\-tenant specific reader/writer role, respectively.
 
-TENANT\_READER \< READER \< TENANT\_WRITER \< WRITER
+TENANT\_READER \< READER \< TENANT\_WRITER \< WRITER.
 
-### func \(DbRoleSlice\) [Swap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L86>)
+### func \(DbRoleSlice\) [Swap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L88>)
 
 ```go
 func (a DbRoleSlice) Swap(i, j int)
@@ -465,7 +465,7 @@ func (a DbRoleSlice) Swap(i, j int)
 type ErrorContextKey string
 ```
 
-### func \(ErrorContextKey\) [String](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L125>)
+### func \(ErrorContextKey\) [String](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/error_codes.go#L126>)
 
 ```go
 func (c ErrorContextKey) String() string
@@ -481,15 +481,15 @@ type InMemory struct {
 }
 ```
 
-### func \(\*InMemory\) [Configure](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L421>)
+### func \(\*InMemory\) [Configure](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L424>)
 
 ```go
 func (inMemory *InMemory) Configure(_ context.Context, isDataStoreInMemory bool, authorizer Authorizer)
 ```
 
-Configures data store to use Postgres or an in\-memory cache
+Configures data store to use Postgres or an in\-memory cache.
 
-### func \(\*InMemory\) [Delete](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L296>)
+### func \(\*InMemory\) [Delete](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L298>)
 
 ```go
 func (inMemory *InMemory) Delete(ctx context.Context, record Record) (int64, error)
@@ -497,19 +497,19 @@ func (inMemory *InMemory) Delete(ctx context.Context, record Record) (int64, err
 
 Deletes a record from cache. record must be a struct.
 
-### func \(\*InMemory\) [DeleteInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L300>)
+### func \(\*InMemory\) [DeleteInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L302>)
 
 ```go
 func (inMemory *InMemory) DeleteInTable(ctx context.Context, cacheName string, record Record) (int64, error)
 ```
 
-### func \(\*InMemory\) [Drop](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L338>)
+### func \(\*InMemory\) [Drop](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L340>)
 
 ```go
 func (inMemory *InMemory) Drop(tableNames ...string) error
 ```
 
-### func \(\*InMemory\) [DropTables](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L330>)
+### func \(\*InMemory\) [DropTables](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L332>)
 
 ```go
 func (inMemory *InMemory) DropTables(records ...Record) error
@@ -551,7 +551,7 @@ func (inMemory *InMemory) FindWithFilter(ctx context.Context, record Record, rec
 
 Finds all records of the requested type. Does not do any filtering. record must be a pointer to a struct. records must be a pointer to a slice of structs.
 
-### func \(\*InMemory\) [FindWithFilterInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L237>)
+### func \(\*InMemory\) [FindWithFilterInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L238>)
 
 ```go
 func (inMemory *InMemory) FindWithFilterInTable(ctx context.Context, cacheName string, record Record, records interface{}) error
@@ -563,7 +563,7 @@ func (inMemory *InMemory) FindWithFilterInTable(ctx context.Context, cacheName s
 func (inMemory *InMemory) GetAuthorizer() Authorizer
 ```
 
-### func \(\*InMemory\) [Insert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L273>)
+### func \(\*InMemory\) [Insert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L274>)
 
 ```go
 func (inMemory *InMemory) Insert(ctx context.Context, record Record) (int64, error)
@@ -571,7 +571,7 @@ func (inMemory *InMemory) Insert(ctx context.Context, record Record) (int64, err
 
 Inserts a record into cache. record must be a struct.
 
-### func \(\*InMemory\) [InsertInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L276>)
+### func \(\*InMemory\) [InsertInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L278>)
 
 ```go
 func (inMemory *InMemory) InsertInTable(_ context.Context, cacheName string, record Record) (int64, error)
@@ -585,7 +585,7 @@ func (inMemory *InMemory) PerformJoinOneToMany(ctx context.Context, record1 Reco
 
 Performs an inner join of in\-memory caches for records record1 and record2. Assumes the relationship between record1 and record2 is one\-to\-many. Stores the retrieved record from the first cache in record1 argument, and the matching records from the second cache in query2Output argument.
 
-TODO \- if the first cache contains the record but the second one doesn't, don't return anything
+TODO \- if the first cache contains the record but the second one doesn't, don't return anything.
 
 ### func \(\*InMemory\) [PerformJoinOneToOne](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L91>)
 
@@ -595,13 +595,13 @@ func (inMemory *InMemory) PerformJoinOneToOne(ctx context.Context, record1 Recor
 
 Performs an inner join of in\-memory caches for records record1 and record2. Assumes the relationship between record1 and record2 is one\-to\-one. Stores the retrieved record from the first cache in record1 argument, and the matching records from the second cache in query2Output argument.
 
-### func \(\*InMemory\) [RegisterWithDAL](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L407>)
+### func \(\*InMemory\) [RegisterWithDAL](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L409>)
 
 ```go
 func (inMemory *InMemory) RegisterWithDAL(ctx context.Context, roleMapping map[string]DbRole, record Record) error
 ```
 
-### func \(\*InMemory\) [RegisterWithDALHelper](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L410>)
+### func \(\*InMemory\) [RegisterWithDALHelper](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L413>)
 
 ```go
 func (inMemory *InMemory) RegisterWithDALHelper(_ context.Context, roleMapping map[string]DbRole, cacheName string, record Record) error
@@ -613,7 +613,7 @@ func (inMemory *InMemory) RegisterWithDALHelper(_ context.Context, roleMapping m
 func (inMemory *InMemory) Reset()
 ```
 
-Reset all the caches in memory and mutexes
+Reset all the caches in memory and mutexes.
 
 ### func \(\*InMemory\) [SetAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L46>)
 
@@ -621,15 +621,15 @@ Reset all the caches in memory and mutexes
 func (inMemory *InMemory) SetAuthorizer(authorizer Authorizer)
 ```
 
-### func \(\*InMemory\) [Truncate](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L346>)
+### func \(\*InMemory\) [Truncate](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L348>)
 
 ```go
 func (inMemory *InMemory) Truncate(tableNames ...string) error
 ```
 
-Deletes all records from cache
+Deletes all records from cache.
 
-### func \(\*InMemory\) [Update](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L360>)
+### func \(\*InMemory\) [Update](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L362>)
 
 ```go
 func (inMemory *InMemory) Update(ctx context.Context, record Record) (int64, error)
@@ -637,19 +637,19 @@ func (inMemory *InMemory) Update(ctx context.Context, record Record) (int64, err
 
 Updates a record in cache. record must be a struct.
 
-### func \(\*InMemory\) [UpdateInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L364>)
+### func \(\*InMemory\) [UpdateInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L366>)
 
 ```go
 func (inMemory *InMemory) UpdateInTable(ctx context.Context, cacheName string, record Record) (int64, error)
 ```
 
-### func \(\*InMemory\) [Upsert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L385>)
+### func \(\*InMemory\) [Upsert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L387>)
 
 ```go
 func (inMemory *InMemory) Upsert(ctx context.Context, record Record) (int64, error)
 ```
 
-### func \(\*InMemory\) [UpsertInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L389>)
+### func \(\*InMemory\) [UpsertInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/inmemory.go#L391>)
 
 ```go
 func (inMemory *InMemory) UpsertInTable(ctx context.Context, cacheName string, record Record) (int64, error)
@@ -671,11 +671,10 @@ type Metadata struct {
 func MetadataFrom(protoStoreMsg ProtoStoreMsg) Metadata
 ```
 
-## type [MetadataBasedAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/authorizer.go#L55-L56>)
+## type [MetadataBasedAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/authorizer.go#L55>)
 
 ```go
-type MetadataBasedAuthorizer struct {
-}
+type MetadataBasedAuthorizer struct{}
 ```
 
 ### func \(MetadataBasedAuthorizer\) [Configure](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/authorizer.go#L124>)
@@ -690,25 +689,25 @@ func (s MetadataBasedAuthorizer) Configure(_ ...interface{})
 func (s MetadataBasedAuthorizer) GetAuthContext(orgId string, roles ...string) context.Context
 ```
 
-### func \(MetadataBasedAuthorizer\) [GetDefaultOrgAdminContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/authorizer.go#L131>)
+### func \(MetadataBasedAuthorizer\) [GetDefaultOrgAdminContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/authorizer.go#L132>)
 
 ```go
 func (s MetadataBasedAuthorizer) GetDefaultOrgAdminContext() context.Context
 ```
 
-### func \(MetadataBasedAuthorizer\) [GetMatchingDbRole](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/authorizer.go#L74>)
+### func \(MetadataBasedAuthorizer\) [GetMatchingDbRole](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/authorizer.go#L73>)
 
 ```go
 func (s MetadataBasedAuthorizer) GetMatchingDbRole(ctx context.Context, tableNames ...string) (DbRole, error)
 ```
 
-### func \(MetadataBasedAuthorizer\) [GetOrgFromContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/authorizer.go#L58>)
+### func \(MetadataBasedAuthorizer\) [GetOrgFromContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/authorizer.go#L57>)
 
 ```go
 func (s MetadataBasedAuthorizer) GetOrgFromContext(ctx context.Context) (string, error)
 ```
 
-### func \(MetadataBasedAuthorizer\) [IsOperationAllowed](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/authorizer.go#L98>)
+### func \(MetadataBasedAuthorizer\) [IsOperationAllowed](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/authorizer.go#L97>)
 
 ```go
 func (s MetadataBasedAuthorizer) IsOperationAllowed(ctx context.Context, tableName string, record Record) error
@@ -783,7 +782,7 @@ type ProtoStore interface {
 }
 ```
 
-### func [GetProtoStore](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L143>)
+### func [GetProtoStore](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L142>)
 
 ```go
 func GetProtoStore() ProtoStore
@@ -799,7 +798,7 @@ type ProtoStoreMock struct {
 }
 ```
 
-### func \(\*ProtoStoreMock\) [Configure](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore_mock.go#L108>)
+### func \(\*ProtoStoreMock\) [Configure](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore_mock.go#L111>)
 
 ```go
 func (p *ProtoStoreMock) Configure(ctx context.Context, isDataStoreInMemory bool, authorizer Authorizer)
@@ -835,7 +834,7 @@ func (p *ProtoStoreMock) FindAllAsMap(ctx context.Context, msgsMap interface{}) 
 func (p *ProtoStoreMock) FindById(ctx context.Context, id string, msg proto.Message, metadata *Metadata) error
 ```
 
-### func \(\*ProtoStoreMock\) [GetAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore_mock.go#L112>)
+### func \(\*ProtoStoreMock\) [GetAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore_mock.go#L115>)
 
 ```go
 func (p *ProtoStoreMock) GetAuthorizer() Authorizer
@@ -859,7 +858,7 @@ func (p *ProtoStoreMock) GetRevision(ctx context.Context, id string, msg proto.M
 func (p *ProtoStoreMock) Insert(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error)
 ```
 
-### func \(\*ProtoStoreMock\) [InsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore_mock.go#L90-L91>)
+### func \(\*ProtoStoreMock\) [InsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore_mock.go#L90-L92>)
 
 ```go
 func (p *ProtoStoreMock) InsertWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (rowsAffected int64, md Metadata, err error)
@@ -877,7 +876,7 @@ func (p *ProtoStoreMock) Register(ctx context.Context, roleMapping map[string]Db
 func (p *ProtoStoreMock) Update(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error)
 ```
 
-### func \(\*ProtoStoreMock\) [UpdateWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore_mock.go#L96-L97>)
+### func \(\*ProtoStoreMock\) [UpdateWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore_mock.go#L97-L99>)
 
 ```go
 func (p *ProtoStoreMock) UpdateWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (rowsAffected int64, md Metadata, err error)
@@ -889,7 +888,7 @@ func (p *ProtoStoreMock) UpdateWithMetadata(ctx context.Context, id string, msg 
 func (p *ProtoStoreMock) Upsert(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error)
 ```
 
-### func \(\*ProtoStoreMock\) [UpsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore_mock.go#L102-L103>)
+### func \(\*ProtoStoreMock\) [UpsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore_mock.go#L104-L106>)
 
 ```go
 func (p *ProtoStoreMock) UpsertWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (rowsAffected int64, md Metadata, err error)
@@ -913,32 +912,31 @@ type ProtoStoreMsg struct {
 func (protoStoreMsg ProtoStoreMsg) GetId() []interface{}
 ```
 
-## type [ProtobufDataStore](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L136-L137>)
+## type [ProtobufDataStore](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L136>)
 
 ```go
-type ProtobufDataStore struct {
-}
+type ProtobufDataStore struct{}
 ```
 
-### func \(ProtobufDataStore\) [Configure](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L147>)
+### func \(ProtobufDataStore\) [Configure](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L146>)
 
 ```go
 func (p ProtobufDataStore) Configure(ctx context.Context, isDataStoreInMemory bool, authorizer Authorizer)
 ```
 
-### func \(ProtobufDataStore\) [DeleteById](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L463>)
+### func \(ProtobufDataStore\) [DeleteById](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L461>)
 
 ```go
 func (p ProtobufDataStore) DeleteById(ctx context.Context, id string, msg proto.Message) (int64, error)
 ```
 
-### func \(ProtobufDataStore\) [DropTables](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L476>)
+### func \(ProtobufDataStore\) [DropTables](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L474>)
 
 ```go
 func (p ProtobufDataStore) DropTables(msgs ...proto.Message) error
 ```
 
-### func \(ProtobufDataStore\) [FindAll](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L412>)
+### func \(ProtobufDataStore\) [FindAll](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L410>)
 
 ```go
 func (p ProtobufDataStore) FindAll(ctx context.Context, msgs interface{}) (metadataMap map[string]Metadata, err error)
@@ -946,7 +944,7 @@ func (p ProtobufDataStore) FindAll(ctx context.Context, msgs interface{}) (metad
 
 Finds all messages \(of the same type as the element of msgs\) in Protostore and stores the result in msgs. msgs must be a pointer to a slice of Protobuf structs or a pointer to a slice of pointers to Protobuf structs. It will be modified in\-place. Returns a map of Protobuf messages' IDs to their metadata \(parent ID & revision\).
 
-### func \(ProtobufDataStore\) [FindAllAsMap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L348>)
+### func \(ProtobufDataStore\) [FindAllAsMap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L346>)
 
 ```go
 func (p ProtobufDataStore) FindAllAsMap(ctx context.Context, msgsMap interface{}) (metadataMap map[string]Metadata, err error)
@@ -960,69 +958,69 @@ func (p ProtobufDataStore) FindById(ctx context.Context, id string, msg proto.Me
 
 Finds a Protobuf message by ID. If metadata arg. is non\-nil, fills it with the metadata \(parent ID & revision\) of the Protobuf message that was found.
 
-### func \(ProtobufDataStore\) [GetAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L139>)
+### func \(ProtobufDataStore\) [GetAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L138>)
 
 ```go
 func (p ProtobufDataStore) GetAuthorizer() Authorizer
 ```
 
-### func \(ProtobufDataStore\) [GetMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L324>)
+### func \(ProtobufDataStore\) [GetMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L323>)
 
 ```go
 func (p ProtobufDataStore) GetMetadata(ctx context.Context, id string, msg proto.Message) (md Metadata, err error)
 ```
 
-### func \(ProtobufDataStore\) [GetRevision](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L339>)
+### func \(ProtobufDataStore\) [GetRevision](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L337>)
 
 ```go
 func (p ProtobufDataStore) GetRevision(ctx context.Context, id string, msg proto.Message) (int64, error)
 ```
 
-### func \(ProtobufDataStore\) [Insert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L165>)
+### func \(ProtobufDataStore\) [Insert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L164>)
 
 ```go
 func (p ProtobufDataStore) Insert(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error)
 ```
 
-Inserts a Protobuf message with the given id and belonging to the given org. into data store
+Inserts a Protobuf message with the given id and belonging to the given org. into data store.
 
-### func \(ProtobufDataStore\) [InsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L169>)
+### func \(ProtobufDataStore\) [InsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L168>)
 
 ```go
 func (p ProtobufDataStore) InsertWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (rowsAffected int64, md Metadata, err error)
 ```
 
-### func \(ProtobufDataStore\) [Register](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L151>)
+### func \(ProtobufDataStore\) [Register](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L150>)
 
 ```go
 func (p ProtobufDataStore) Register(ctx context.Context, roleMapping map[string]DbRole, msgs ...proto.Message) error
 ```
 
-### func \(ProtobufDataStore\) [Update](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L208>)
+### func \(ProtobufDataStore\) [Update](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L207>)
 
 ```go
 func (p ProtobufDataStore) Update(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error)
 ```
 
-Fetches metadata for the record and updates the Protobuf message. NOTE: Avoid using this method in user\-workflows and only in service\-to\-service workflows when the updates are already ordered by some other service/app
+Fetches metadata for the record and updates the Protobuf message. NOTE: Avoid using this method in user\-workflows and only in service\-to\-service workflows when the updates are already ordered by some other service/app.
 
-### func \(ProtobufDataStore\) [UpdateWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L219>)
+### func \(ProtobufDataStore\) [UpdateWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L218>)
 
 ```go
 func (p ProtobufDataStore) UpdateWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (rowsAffected int64, md Metadata, err error)
 ```
 
-Updates a Protobuf message
+Updates a Protobuf message.
 
-### func \(ProtobufDataStore\) [Upsert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L253>)
+### func \(ProtobufDataStore\) [Upsert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L252>)
 
 ```go
 func (p ProtobufDataStore) Upsert(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error)
 ```
 
-Fetches metadata for the record and upserts the Protobuf message. NOTE: Avoid using this method in user\-workflows and only in service\-to\-service workflows when the updates are already ordered by some other service/app
+Fetches metadata for the record and upserts the Protobuf message. NOTE: Avoid using this method in user\-workflows and only in service\-to\-service workflows when the updates are already ordered by some other service/app.
 
-### func \(ProtobufDataStore\) [UpsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L266-L267>)
+### func \(ProtobufDataStore\) [UpsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/protostore.go#L265-L267>)
 
 ```go
 func (p ProtobufDataStore) UpsertWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (rowsAffected int64, md Metadata, err error)
@@ -1046,7 +1044,7 @@ type Record interface {
 func GetRecordInstanceFromSlice(x interface{}) Record
 ```
 
-## type [RelationalDb](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L123-L126>)
+## type [RelationalDb](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L125-L128>)
 
 Postgres\-backed implementation of DataStore interface. By default, uses MetadataBasedAuthorizer for authentication & authorization.
 
@@ -1056,7 +1054,7 @@ type RelationalDb struct {
 }
 ```
 
-### func \(\*RelationalDb\) [Configure](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L1064>)
+### func \(\*RelationalDb\) [Configure](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L1063>)
 
 ```go
 func (database *RelationalDb) Configure(_ context.Context, isDataStoreInMemory bool, authorizer Authorizer)
@@ -1064,23 +1062,23 @@ func (database *RelationalDb) Configure(_ context.Context, isDataStoreInMemory b
 
 Configures data store to use Postgres or an in\-memory cache. Should be called when microservice starts up.
 
-### func \(\*RelationalDb\) [Delete](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L669>)
+### func \(\*RelationalDb\) [Delete](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L668>)
 
 ```go
 func (database *RelationalDb) Delete(ctx context.Context, record Record) (int64, error)
 ```
 
-Deletes a record from a DB table
+Deletes a record from a DB table.
 
-### func \(\*RelationalDb\) [DeleteInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L750>)
+### func \(\*RelationalDb\) [DeleteInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L749>)
 
 ```go
 func (database *RelationalDb) DeleteInTable(ctx context.Context, tableName string, record Record) (int64, error)
 ```
 
-Deletes a record from DB table tableName
+Deletes a record from DB table tableName.
 
-### func \(\*RelationalDb\) [Drop](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L702>)
+### func \(\*RelationalDb\) [Drop](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L701>)
 
 ```go
 func (database *RelationalDb) Drop(tableNames ...string) error
@@ -1088,13 +1086,13 @@ func (database *RelationalDb) Drop(tableNames ...string) error
 
 Drops given DB tables.
 
-### func \(\*RelationalDb\) [DropTables](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L676>)
+### func \(\*RelationalDb\) [DropTables](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L675>)
 
 ```go
 func (database *RelationalDb) DropTables(records ...Record) error
 ```
 
-\* Drops the DB tables given by Records
+\* Drops the DB tables given by Records.
 
 ### func \(\*RelationalDb\) [Find](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L464>)
 
@@ -1104,7 +1102,7 @@ func (database *RelationalDb) Find(ctx context.Context, record Record) error
 
 Finds a single record that has the same primary key as record. record argument must be a pointer to a struct and will be modified in\-place. Returns RecordNotFoundError if a record could not be found.
 
-### func \(\*RelationalDb\) [FindAll](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L531>)
+### func \(\*RelationalDb\) [FindAll](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L530>)
 
 ```go
 func (database *RelationalDb) FindAll(ctx context.Context, records interface{}) error
@@ -1112,7 +1110,7 @@ func (database *RelationalDb) FindAll(ctx context.Context, records interface{}) 
 
 Finds all records in a DB table. records must be a pointer to a slice of structs and will be modified in\-place.
 
-### func \(\*RelationalDb\) [FindAllInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L547>)
+### func \(\*RelationalDb\) [FindAllInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L546>)
 
 ```go
 func (database *RelationalDb) FindAllInTable(ctx context.Context, tableName string, records interface{}) error
@@ -1128,7 +1126,7 @@ func (database *RelationalDb) FindInTable(ctx context.Context, tableName string,
 
 Finds a single record in table tableName that has the same primary key as record. record argument must be a pointer to a struct and will be modified in\-place. Returns RecordNotFoundError if a record could not be found.
 
-### func \(\*RelationalDb\) [FindWithFilter](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L561>)
+### func \(\*RelationalDb\) [FindWithFilter](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L560>)
 
 ```go
 func (database *RelationalDb) FindWithFilter(ctx context.Context, record Record, records interface{}) error
@@ -1136,7 +1134,7 @@ func (database *RelationalDb) FindWithFilter(ctx context.Context, record Record,
 
 Finds multiple records in a DB table. If record argument is non\-empty, uses the non\-empty fields as criteria in a query. records must be a pointer to a slice of structs and will be modified in\-place.
 
-### func \(\*RelationalDb\) [FindWithFilterInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L570>)
+### func \(\*RelationalDb\) [FindWithFilterInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L569>)
 
 ```go
 func (database *RelationalDb) FindWithFilterInTable(ctx context.Context, tableName string, record Record, records interface{}) error
@@ -1144,21 +1142,21 @@ func (database *RelationalDb) FindWithFilterInTable(ctx context.Context, tableNa
 
 Finds multiple records in DB table tableName. If record argument is non\-empty, uses the non\-empty fields as criteria in a query. records must be a pointer to a slice of structs and will be modified in\-place.
 
-### func \(\*RelationalDb\) [GetAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L1057>)
+### func \(\*RelationalDb\) [GetAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L1056>)
 
 ```go
 func (database *RelationalDb) GetAuthorizer() Authorizer
 ```
 
-### func \(\*RelationalDb\) [Insert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L626>)
+### func \(\*RelationalDb\) [Insert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L625>)
 
 ```go
 func (database *RelationalDb) Insert(ctx context.Context, record Record) (int64, error)
 ```
 
-Inserts a record into a DB table
+Inserts a record into a DB table.
 
-### func \(\*RelationalDb\) [InsertInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L633>)
+### func \(\*RelationalDb\) [InsertInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L632>)
 
 ```go
 func (database *RelationalDb) InsertInTable(ctx context.Context, tableName string, record Record) (int64, error)
@@ -1180,9 +1178,9 @@ Performs an inner join between 2 non\-multitenant DB tables, joining them on the
 func (database *RelationalDb) PerformJoinOneToOne(ctx context.Context, record1 Record, record1Id string, record2 Record, record2JoinOnColumn string) error
 ```
 
-Performs an inner join between 2 non\-multitenant DB tables, joining them on the key column of the first table and the "record2JoinOnField" column of the 2nd table. Assumes the following: \- There is a one\-to\-one relationship between the two tables \- Both tables either have primary keys consisting of one column \(ID\) or a composite key that is a combination of record ID and org. ID Requires a unique ID of the record in the first table to be passed, which leads to only one record to be returned. record1 and record2 must be pointers to structs implementing Record interface and represent entities persisted to the 2 DB tables. record1 and record2 will be filled with data retrieved from the 2 DB tables. TODO return ErrOperationNotAllowed if the library user is trying to access other tenant's data
+Performs an inner join between 2 non\-multitenant DB tables, joining them on the key column of the first table and the "record2JoinOnField" column of the 2nd table. Assumes the following: \- There is a one\-to\-one relationship between the two tables \- Both tables either have primary keys consisting of one column \(ID\) or a composite key that is a combination of record ID and org. ID Requires a unique ID of the record in the first table to be passed, which leads to only one record to be returned. record1 and record2 must be pointers to structs implementing Record interface and represent entities persisted to the 2 DB tables. record1 and record2 will be filled with data retrieved from the 2 DB tables. TODO return ErrOperationNotAllowed if the library user is trying to access other tenant's data.
 
-### func \(\*RelationalDb\) [RegisterWithDAL](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L876>)
+### func \(\*RelationalDb\) [RegisterWithDAL](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L875>)
 
 ```go
 func (database *RelationalDb) RegisterWithDAL(ctx context.Context, roleMapping map[string]DbRole, record Record) error
@@ -1190,7 +1188,7 @@ func (database *RelationalDb) RegisterWithDAL(ctx context.Context, roleMapping m
 
 Registers a struct with DAL. See RegisterWithDALHelper\(\) for more info.
 
-### func \(\*RelationalDb\) [RegisterWithDALHelper](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L896>)
+### func \(\*RelationalDb\) [RegisterWithDALHelper](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L895>)
 
 ```go
 func (database *RelationalDb) RegisterWithDALHelper(_ context.Context, roleMapping map[string]DbRole, tableName string, record Record) error
@@ -1198,7 +1196,7 @@ func (database *RelationalDb) RegisterWithDALHelper(_ context.Context, roleMappi
 
 Create a DB table for the given struct. Enables RLS in it if it is multi\-tenant. Generates Postgres roles and policies based on the provided role mapping and applies them to the created DB table. roleMapping \- maps service roles to DB roles to be used for the generated DB table There are 4 possible DB roles to choose from: \- READER, which gives read access to all the records in the table \- WRITER\*, which gives read & write access to all the records in the table \- TENANT\_READER, which gives read access to current tenant's records \- TENANT\_WRITER, which gives read & write access to current tenant's records
 
-Panics if the struct doesn't pass the following validations: \- Each field has to have a tag indicating the name of the relevant column in DB table \- Each field has to be exported \- Each field has to be of a supported data type \(signed integral data types, boolean, strings\)
+Panics if the struct doesn't pass the following validations: \- Each field has to have a tag indicating the name of the relevant column in DB table \- Each field has to be exported \- Each field has to be of a supported data type \(signed integral data types, boolean, strings\).
 
 ### func \(\*RelationalDb\) [Reset](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L301>)
 
@@ -1206,45 +1204,45 @@ Panics if the struct doesn't pass the following validations: \- Each field has t
 func (database *RelationalDb) Reset()
 ```
 
-Resets DB connection pools
+Resets DB connection pools.
 
-### func \(\*RelationalDb\) [Truncate](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L724>)
+### func \(\*RelationalDb\) [Truncate](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L723>)
 
 ```go
 func (database *RelationalDb) Truncate(tableNames ...string) error
 ```
 
-### func \(\*RelationalDb\) [Update](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L786>)
+### func \(\*RelationalDb\) [Update](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L785>)
 
 ```go
 func (database *RelationalDb) Update(ctx context.Context, record Record) (int64, error)
 ```
 
-Updates a record in a DB table
+Updates a record in a DB table.
 
-### func \(\*RelationalDb\) [UpdateInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L793>)
+### func \(\*RelationalDb\) [UpdateInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L792>)
 
 ```go
 func (database *RelationalDb) UpdateInTable(ctx context.Context, tableName string, record Record) (int64, error)
 ```
 
-Updates a record in DB table tableName
+Updates a record in DB table tableName.
 
-### func \(\*RelationalDb\) [Upsert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L832>)
+### func \(\*RelationalDb\) [Upsert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L831>)
 
 ```go
 func (database *RelationalDb) Upsert(ctx context.Context, record Record) (int64, error)
 ```
 
-Upserts a record in a DB table
+Upserts a record in a DB table.
 
-### func \(\*RelationalDb\) [UpsertInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L839>)
+### func \(\*RelationalDb\) [UpsertInTable](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/data-access-layer/datastore/database.go#L838>)
 
 ```go
 func (database *RelationalDb) UpsertInTable(ctx context.Context, tableName string, record Record) (int64, error)
 ```
 
-Upserts a record in DB table tableName
+Upserts a record in DB table tableName.
 
 
 


### PR DESCRIPTION
- Cleanup the repo by running `golangci-lint run --enable-all --fix` (or) `make lint_fix`
- Adjust linter configuration to disable some linter for test files