### PR TITLE
Remove usage of Helper() interface from protostore

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,44 @@
+---
+name: Daily
+on:
+  schedule:
+  - cron: "0 6 * * *"
+
+jobs:
+  test:
+    name: Unit test
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go using version from go.mod
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run unit tests
+        run: |
+          mkdir -p $(go env GOPATH)
+          mkdir -p $(go env GOCACHE)
+          sudo make test
+      - name: Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: test-results/coverage.out
+          flags: unit-tests
+          name: codecov-unit-test
+
+  lint:
+    name: Check lint
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go using version from go.mod
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+      - name: Run lint
+        run: |
+          mkdir -p $(go env GOPATH)
+          mkdir -p $(go env GOCACHE)
+          make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -172,6 +172,9 @@ issues:
         - gosec
         - typecheck
         - unparam
+    - path: pkg/datastore/logger.go
+      linters:
+        - gochecknoglobals
     - path: pkg/datastore/sql_struct.go
       linters:
         - gochecknoglobals

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint_fix: ## Run golang linters in fix mode
 	build/lint_fix.sh
 
 test:  install_tools ## Run unit-tests
-	build/unit_tests.sh
+	LOG_LEVEL=trace build/unit_tests.sh
 
 benchmarks:
 	build/benchmarks.sh

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub Actions](https://github.com/vmware-labs/multi-tenant-persistence-for-saas/actions/workflows/go.yml/badge.svg)](https://github.com/vmware-labs/multi-tenant-persistence-for-saas/actions?query=branch%3Amaster)
 [![Go Reference](https://pkg.go.dev/badge/github.com/vmware-labs/multi-tenant-persistence-for-saas/)](https://pkg.go.dev/github.com/vmware-labs/multi-tenant-persistence-for-saas)
 [![Code Coverage](https://codecov.io/gh/vmware-labs/multi-tenant-persistence-for-saas/branch/main/graph/badge.svg?token=F7TQPSFEMCN)](https://app.codecov.io/gh/vmware-labs/multi-tenant-persistence-for-saas)
+[![Daily](https://github.com/vmware-labs/multi-tenant-persistence-for-saas/actions/workflows/daily.yml/badge.svg)](https://github.com/vmware-labs/multi-tenant-persistence-for-saas/actions/workflows/daily.yml)
 
 
 ## Overview
@@ -70,22 +71,13 @@ Currently, following features are supported:
 
 Following interfaces are exposed by the Golang library to be consumed by the user of this library,
 
-### [Authorizer](docs/DOCUMENTATION.md#type-authorizer)
+### [Authorizer](docs/DOCUMENTATION.md#authorizer)
 
-### [Record](docs/DOCUMENTATION.md#type-record)
+### [DataStore](docs/DOCUMENTATION.md#datastore)
 
-### [DataStore](docs/DOCUMENTATION.md#type-datastore)
-
-### [ProtoStore](docs/DOCUMENTATION.md#type-protostore)
+### [ProtoStore](docs/DOCUMENTATION.md#protostore)
 
 ## Getting Started
-
-Import the package and use `DataStore` object to interact with the data access
-layer. If you want DAL to use a Postgres database, ensure you have the following
-environment variables set to relevant values: *DB_ADMIN_USERNAME*, *DB_PORT*,
-*DB_NAME*, *DB_ADMIN_PASSWORD*, *DB_HOST*, *SSL_MODE*. You can also set
-*LOG_LEVEL* environment variable if you want logging at a specific level
-(default is _Info_)
 
 ## Future Support
 

--- a/build/setup_local_postgres.sh
+++ b/build/setup_local_postgres.sh
@@ -20,8 +20,8 @@ if [[ $(uname -s) == "Linux" ]]; then
   fi
   su - postgres -c "psql << end_of_sql
 alter user postgres with password 'postgres';
-drop database test_tmp_db_;
-create database test_tmp_db_;
+drop database tmp_db;
+create database tmp_db;
 end_of_sql"
 
 elif [[ $(uname -s) == "Darwin" ]]; then
@@ -36,11 +36,11 @@ elif [[ $(uname -s) == "Darwin" ]]; then
     brew services info postgresql@14 --json | jq '.[0].running' | grep true
     echo "postgresql: Installation successful"
   fi
-  dropdb test_tmp_db_ --if-exists
-  createdb test_tmp_db_
-  echo "create user postgres superuser" | psql test_tmp_db_ || echo "User postgres exists"
-  echo "alter user postgres with password 'postgres'" | psql test_tmp_db_
-  echo "alter user postgres with superuser;" | psql test_tmp_db_
+  dropdb tmp_db --if-exists
+  createdb tmp_db
+  echo "create user postgres superuser" | psql tmp_db || echo "User postgres exists"
+  echo "alter user postgres with password 'postgres'" | psql tmp_db
+  echo "alter user postgres with superuser;" | psql tmp_db
 fi
 
-export DB_NAME=test_tmp_db_ DB_PORT=5432 DB_ADMIN_USERNAME=postgres DB_ADMIN_PASSWORD=postgres DB_HOST=localhost SSL_MODE=disable
+export DB_NAME=tmp_db DB_PORT=5432 DB_ADMIN_USERNAME=postgres DB_ADMIN_PASSWORD=postgres DB_HOST=localhost SSL_MODE=disable

--- a/build/unit_tests.sh
+++ b/build/unit_tests.sh
@@ -17,10 +17,10 @@ fi
 echo "Creating results directory to store unit tests result"
 mkdir -p $RESULTS_DIR
 
-if [[ "debug" == "${LOG_LEVEL:-unset}" ]]; then
-  TEST_VERBOSE="-v "
-else
+if [[ "unset" == "${LOG_LEVEL:-unset}" ]]; then
   TEST_VERBOSE=""
+else
+  TEST_VERBOSE="-v "
 fi
 
 echo "running go test, excluding test and proto folders"

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -16,6 +16,57 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Import the package and use `DataStore` interface to interact with the data access
+// layer. If you want DAL to use a Postgres database, ensure you have the following
+// environment variables set to relevant values: *DB_ADMIN_USERNAME*, *DB_PORT*,
+// *DB_NAME*, *DB_ADMIN_PASSWORD*, *DB_HOST*, *SSL_MODE*. You can also set
+// *LOG_LEVEL* environment variable to debug/trace, if you want logging at a
+// specific level (default is _Info_)
+//
+// Define structs that will be persisted using datastore similar to any gorm Models,
+// for reference [https://gorm.io/docs/models.html]
+//
+// - At least one field must be a primary key (contain a *primary_key* tag with the value of *true*).
+// - For revision support to block concurrent updates, add __revision_ as column tag.
+// - For multi-tenancy support, add an _org_id_ tag to a field.
+//
+//		type App struct {
+//			Id       string `gorm:"primaryKey;column:application_id"`
+//			Name     string
+//			TenantId string `gorm:"primaryKey;column:org_id"`
+//			Revision int64  `gorm:"column:revision"`
+//		}
+//
+//	DataStore.RegisterWithDAL(context.TODO(), roleMappingForAppUser, appUser{})
+//
+//	datastore.DataStore.Insert(ctx, user1)
+//	var queryResult appUser = appUser{Id: user1.Id}
+//	DataStore.Find(ctx, &queryResult)
+//
+//	queryResults := make([]appUser, 0)
+//	DataStore.FindAll(ctx, &queryResults)
+//
+//	DataStore.Delete(ctx, user1)
+//
+// DataStore interface exposes basic methods like Find/FindAll/Upsert/Delete, for richer queries
+// and transaction based filtering and pagination please use GetTransaction() method.
+// Sample usage using db transactions,
+//
+//	t.Log("Getting DBTransaction for creating App and AppUser")
+//	tx, err := TestDataStore.GetTransaction(CokeAdminCtx, app, appUser)
+//	assert.NoError(err)
+//	t.Log("Creating app and appUser in single transaction")
+//	err = tx.Transaction(func(tx *gorm.DB) error {
+//		if err := tx.Create(app).Error; err != nil {
+//			return err
+//		}
+//		if err := tx.Create(appUser).Error; err != nil {
+//			return err
+//		}
+//
+//		return nil
+//	})
+//	tx.Commit()
 package datastore
 
 import (
@@ -44,16 +95,9 @@ type DataStore interface {
 }
 
 type Helper interface {
-	GetAuthorizer() authorizer.Authorizer
 	GetDBTransaction(ctx context.Context, tableName string, record Record) (tx *gorm.DB, err error)
-	RegisterWithDALHelper(ctx context.Context, roleMapping map[string]dbrole.DbRole, tableName string, record Record) error
-	FindInTable(ctx context.Context, tableName string, record Record) error
 	FindAllInTable(ctx context.Context, tableName string, records interface{}) error
 	FindWithFilterInTable(ctx context.Context, tableName string, record Record, records interface{}) error
-	InsertInTable(ctx context.Context, tableName string, record Record) (int64, error)
-	UpdateInTable(ctx context.Context, tableName string, record Record) (int64, error)
-	UpsertInTable(ctx context.Context, tableName string, record Record) (int64, error)
-	DeleteInTable(ctx context.Context, tableName string, record Record) (int64, error)
 }
 
 type TestHelper interface {

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -616,4 +616,5 @@ func TestRevision(t *testing.T) {
 func TestTransactions(t *testing.T) {
 	testSingleTableTransactions(t)
 	testMultiTableTransactions(t)
+	testMultiProtoTransactions(t)
 }

--- a/pkg/datastore/sql_struct_test.go
+++ b/pkg/datastore/sql_struct_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/datastore"
 	. "github.com/vmware-labs/multi-tenant-persistence-for-saas/test"
+	"github.com/vmware-labs/multi-tenant-persistence-for-saas/test/pb"
 )
 
 /*
@@ -32,19 +33,61 @@ Checks if table name can be extracted from struct/slice of structs using utility
 func TestGettingTableName(t *testing.T) {
 	assert := assert.New(t)
 
-	assert.Equal("application", datastore.GetTableName(App{}))
-	assert.Equal("application", datastore.GetTableName(&App{}))
+	{
+		for _, x := range []interface{}{
+			App{},
+			&App{},
+			[]App{},
+			&[]App{},
+			[]*App{},
+			&[]*App{},
+		} {
+			t.Logf("Testing GetTableName with %+v", datastore.TypeName(x))
+			assert.Equal("application", datastore.GetTableName(x))
+		}
+	}
 
-	assert.Equal("app_users", datastore.GetTableName(AppUser{}))
-	assert.Equal("app_users", datastore.GetTableName(&AppUser{}))
+	{
+		for _, x := range []interface{}{
+			AppUser{},
+			&AppUser{},
+			[]AppUser{},
+			&[]AppUser{},
+			[]*AppUser{},
+			&[]*AppUser{},
+		} {
+			t.Logf("Testing GetTableName with %+v", datastore.TypeName(x))
+			assert.Equal("app_users", datastore.GetTableName(x))
+		}
+	}
 
-	assert.Equal("groups", datastore.GetTableName(Group{}))
-	assert.Equal("groups", datastore.GetTableName(&Group{}))
+	{
+		for _, x := range []interface{}{
+			Group{},
+			&Group{},
+			[]Group{},
+			&[]Group{},
+			[]*Group{},
+			&[]*Group{},
+		} {
+			t.Logf("Testing GetTableName with %+v", datastore.TypeName(x))
+			assert.Equal("groups", datastore.GetTableName(x))
+		}
+	}
 
-	assert.Equal("app_users", datastore.GetTableNameFromSlice([]AppUser{}))
-	assert.Equal("app_users", datastore.GetTableNameFromSlice(&[]AppUser{}))
-	assert.Equal("app_users", datastore.GetTableNameFromSlice([]*AppUser{}))
-	assert.Equal("app_users", datastore.GetTableNameFromSlice(&[]*AppUser{}))
+	{
+		for _, x := range []interface{}{
+			pb.CPU{},
+			&pb.CPU{},
+			[]pb.CPU{},
+			[]*pb.CPU{},
+			&[]pb.CPU{},
+			&[]*pb.CPU{},
+		} {
+			t.Logf("Testing GetTableName with %+v", datastore.TypeName(x))
+			assert.Equal("processor", datastore.GetTableName(x))
+		}
+	}
 }
 
 func TestIsRevisioningSupported(t *testing.T) {

--- a/pkg/dbrole/dbrole.go
+++ b/pkg/dbrole/dbrole.go
@@ -16,19 +16,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/*
-DAL uses 4 database roles/users to perform all operations:
-
-- `TENANT_READER` - has read access to its tenant's data
-- `READER` - has read access to all tenants' data
-- `TENANT_WRITER` - has read & write access to its tenant's data
-- `WRITER` - has read & write access to all tenants' data
-
-DAL allows to map a user's service role to the DB role that will be used for
-that user. If a user has multiple service roles which map to several DB roles,
-the DB role with the most extensive privileges will be used (see `DbRoles()`
-for reference to ordered list of DbRoles.
-*/
+//	 DAL uses 4 database roles/users to perform all operations,
+//
+//		- `TENANT_READER` - has read access to its tenant's data
+//		- `READER` - has read access to all tenants' data
+//		- `TENANT_WRITER` - has read & write access to its tenant's data
+//		- `WRITER` - has read & write access to all tenants' data
+//
+//	 DAL allows to map a user's service role to the DB role that will be used for
+//	 that user. If a user has multiple service roles which map to several DB roles,
+//	 the DB role with the most extensive privileges will be used (see `DbRoles()`
+//	 for reference to ordered list of DbRoles.
 package dbrole
 
 // DbRole Database roles/users.

--- a/pkg/protostore/protostore_test.go
+++ b/pkg/protostore/protostore_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bxcodec/faker/v3"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/datastore"
 	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/dbrole"
 	. "github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/errors"
 	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/protostore"
@@ -192,8 +193,8 @@ func testProtoStoreFindWithInvalidParams(t *testing.T, ctx context.Context) {
 			map[string]*pb.CPU{},
 		}
 
-		for i := range invalidParams {
-			invalidParam := invalidParams[i]
+		for _, invalidParam := range invalidParams {
+			t.Logf("Testing with invalidParam %s=%+v", datastore.TypeName(invalidParam), invalidParam)
 			_, err := p.FindAll(ctx, invalidParam)
 			assert.ErrorIs(err, ErrNotPtrToStructSlice)
 		}
@@ -203,8 +204,8 @@ func testProtoStoreFindWithInvalidParams(t *testing.T, ctx context.Context) {
 			&[]*pb.CPU{},
 		}
 
-		for i := range validParams {
-			validParam := validParams[i]
+		for _, validParam := range validParams {
+			t.Logf("Testing with validParam %s=%+v", datastore.TypeName(validParam), validParam)
 			_, err := p.FindAll(ctx, validParam)
 			assert.NoError(err)
 		}


### PR DESCRIPTION
    - Add TRACE() for debugging with additional logging
    - LOG_LEVEL=trace enables TRACE() and logging at Trace level
    - Exposed MsgToPersist/MsgToFilter for supporting multiple
    operations using single GetTransaction
    - Added unit test for Transaction with protoStore and dataStore objects
    - Minor fixes to the DOCUMENTATION.md (still WIP)
    - Add daily run to catch issues with race conditions in unit-tests