### PR TITLE
Add support for multi instances access data from same datastore. Closes #18

### DIFF
--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -16,57 +16,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Import the package and use `DataStore` interface to interact with the data access
-// layer. If you want DAL to use a Postgres database, ensure you have the following
-// environment variables set to relevant values: *DB_ADMIN_USERNAME*, *DB_PORT*,
-// *DB_NAME*, *DB_ADMIN_PASSWORD*, *DB_HOST*, *SSL_MODE*. You can also set
-// *LOG_LEVEL* environment variable to debug/trace, if you want logging at a
-// specific level (default is _Info_)
-//
-// Define structs that will be persisted using datastore similar to any gorm Models,
-// for reference [https://gorm.io/docs/models.html]
-//
-// - At least one field must be a primary key (contain a *primary_key* tag with the value of *true*).
-// - For revision support to block concurrent updates, add __revision_ as column tag.
-// - For multi-tenancy support, add an _org_id_ tag to a field.
-//
-//		type App struct {
-//			Id       string `gorm:"primaryKey;column:application_id"`
-//			Name     string
-//			TenantId string `gorm:"primaryKey;column:org_id"`
-//			Revision int64  `gorm:"column:revision"`
-//		}
-//
-//	DataStore.Register(context.TODO(), roleMappingForAppUser, appUser{})
-//
-//	datastore.DataStore.Insert(ctx, user1)
-//	var queryResult appUser = appUser{Id: user1.Id}
-//	DataStore.Find(ctx, &queryResult)
-//
-//	queryResults := make([]appUser, 0)
-//	DataStore.FindAll(ctx, &queryResults)
-//
-//	DataStore.Delete(ctx, user1)
-//
-// DataStore interface exposes basic methods like Find/FindAll/Upsert/Delete, for richer queries
-// and transaction based filtering and pagination please use GetTransaction() method.
-// Sample usage using db transactions,
-//
-//	t.Log("Getting DBTransaction for creating App and AppUser")
-//	tx, err := TestDataStore.GetTransaction(CokeAdminCtx, app, appUser)
-//	assert.NoError(err)
-//	t.Log("Creating app and appUser in single transaction")
-//	err = tx.Transaction(func(tx *gorm.DB) error {
-//		if err := tx.Create(app).Error; err != nil {
-//			return err
-//		}
-//		if err := tx.Create(appUser).Error; err != nil {
-//			return err
-//		}
-//
-//		return nil
-//	})
-//	tx.Commit()
+/*
+Import the package and use `DataStore` interface to interact with the data access
+layer. If you want DAL to use a Postgres database, ensure you have the following
+environment variables set to relevant values: `DB_ADMIN_USERNAME`, `DB_PORT`,
+`DB_NAME`, `DB_ADMIN_PASSWORD`, `DB_HOST`, `SSL_MODE`. You can also set
+`LOG_LEVEL` environment variable to debug/trace, if you want logging at a
+specific level (default is `Info`)
+
+Define structs that will be persisted using datastore similar to any gorm Models,
+for reference https://gorm.io/docs/models.html
+
+  - At least one field must be a primary key with `gorm:"primaryKey"` tag
+  - For multi-tenancy support, add `gorm:"column:org_id"` as tag to a filed
+  - For revision support to block concurrent updates, add `gorm:"column:revision"` as tag
+  - For multi-instance support, add `gorm:"column:instance_id"` as tag
+
+DataStore interface exposes basic methods like Find/FindAll/Upsert/Delete, for richer queries
+and transaction based filtering and pagination please use GetTransaction() method.
+*/
 package datastore
 
 import (
@@ -77,7 +45,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// DataStore /*.
 type DataStore interface {
 	Find(ctx context.Context, record Record) error
 	FindAll(ctx context.Context, records interface{}, pagination *Pagination) error
@@ -92,6 +59,7 @@ type DataStore interface {
 	Reset()
 
 	GetAuthorizer() authorizer.Authorizer
+	GetInstancer() authorizer.Instancer
 	Helper() Helper
 	TestHelper() TestHelper
 }

--- a/pkg/datastore/example_multiinstance_test.go
+++ b/pkg/datastore/example_multiinstance_test.go
@@ -1,0 +1,101 @@
+package datastore_test
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/authorizer"
+	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/datastore"
+	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/dbrole"
+	. "github.com/vmware-labs/multi-tenant-persistence-for-saas/test"
+)
+
+type Person struct {
+	Id         string `gorm:"primaryKey"`
+	Name       string
+	Age        int
+	InstanceId string `gorm:"primaryKey"`
+}
+
+func (p Person) String() string {
+	return fmt.Sprintf("%s: %d", p.Name, p.Age)
+}
+
+func Example_dataStoreMultiInstance() {
+	rand.Seed(time.Now().UnixNano())
+	uId := fmt.Sprintf("P%d", rand.Intn(1_000_0000))
+	p1 := &Person{uId, "Bob", 31, "Dev"}
+	p2 := &Person{uId, "John", 36, "Prod"}
+	p3 := &Person{"P3", "Pat", 39, "Dev"}
+
+	mdAuthorizer := authorizer.MetadataBasedAuthorizer{}
+	instancer := authorizer.SimpleInstancer{}
+
+	DevInstanceCtx := TestInstancer.WithInstanceId(ServiceAdminCtx, "Dev")
+	ProdInstanceCtx := TestInstancer.WithInstanceId(ServiceAdminCtx, "Prod")
+
+	ds, _ := datastore.FromEnv(datastore.GetCompLogger(), mdAuthorizer, instancer)
+	roleMapping := map[string]dbrole.DbRole{
+		SERVICE_AUDITOR: dbrole.READER,
+		SERVICE_ADMIN:   dbrole.WRITER,
+	}
+
+	if err := ds.Register(DevInstanceCtx, roleMapping, &Person{}); err != nil {
+		log.Fatalf("Failed to create DB tables: %+v", err)
+	}
+
+	// Insert with appropriate Dev Instance Ctx
+	rowsAffected, err := ds.Insert(DevInstanceCtx, p1)
+	fmt.Println(rowsAffected, err)
+
+	// Insert with appropriate Prod Instance Ctx
+	rowsAffected, err = ds.Insert(ProdInstanceCtx, p2)
+	fmt.Println(rowsAffected, err)
+
+	// Insert with appropriate Dev Instance Ctx
+	rowsAffected, err = ds.Insert(DevInstanceCtx, p3)
+	fmt.Println(rowsAffected, err)
+
+	q1 := &Person{Id: uId}
+	err = ds.Find(DevInstanceCtx, q1)
+	fmt.Println(q1, err)
+
+	q2 := &Person{Id: uId}
+	err = ds.Find(ProdInstanceCtx, q2)
+	fmt.Println(q2, err)
+
+	// Find using valid Dev Instance Ctx
+	q3 := &Person{Id: "P3"}
+	err = ds.Find(DevInstanceCtx, q3)
+	fmt.Println(q3, err)
+
+	// Find using invalid Prod Instance Ctx
+	q4 := &Person{Id: "P3"}
+	err = ds.Find(ProdInstanceCtx, q4)
+	fmt.Println(err)
+
+	rowsAffected, err = ds.Delete(DevInstanceCtx, q1)
+	fmt.Println(rowsAffected, err)
+	rowsAffected, err = ds.Delete(ProdInstanceCtx, q2)
+	fmt.Println(rowsAffected, err)
+	// Delete  using invalid Prod Instance Ctx
+	rowsAffected, err = ds.Delete(ProdInstanceCtx, q4)
+	fmt.Println(rowsAffected, err)
+	// Delete using valid Dev Instance Ctx
+	rowsAffected, err = ds.Delete(DevInstanceCtx, q3)
+	fmt.Println(rowsAffected, err)
+	// Output:
+	// 1 <nil>
+	// 1 <nil>
+	// 1 <nil>
+	// Bob: 31 <nil>
+	// John: 36 <nil>
+	// Pat: 39 <nil>
+	// Record not found: Unable to locate a record: : 0
+	// 1 <nil>
+	// 1 <nil>
+	// 0 <nil>
+	// 1 <nil>
+}

--- a/pkg/datastore/example_noinstancer_test.go
+++ b/pkg/datastore/example_noinstancer_test.go
@@ -1,0 +1,101 @@
+package datastore_test
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/authorizer"
+	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/datastore"
+	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/dbrole"
+	. "github.com/vmware-labs/multi-tenant-persistence-for-saas/test"
+)
+
+type xUser struct {
+	Id         string `gorm:"primaryKey"`
+	Name       string
+	Age        int
+	InstanceId string
+}
+
+func (p xUser) String() string {
+	return fmt.Sprintf("%s: %d", p.Name, p.Age)
+}
+
+func Example_dataStoreNoInstancer() {
+	rand.Seed(time.Now().UnixNano())
+	uId := fmt.Sprintf("P%d", rand.Intn(1_000_0000))
+	p1 := &xUser{uId, "Bob", 31, "Dev"}
+	p2 := &xUser{uId, "John", 36, "Prod"}
+	p3 := &xUser{"P3", "Pat", 39, "Dev"}
+
+	mdAuthorizer := authorizer.MetadataBasedAuthorizer{}
+	instancer := authorizer.SimpleInstancer{}
+
+	DevInstanceCtx := instancer.WithInstanceId(ServiceAdminCtx, "Dev")
+	ProdInstanceCtx := instancer.WithInstanceId(ServiceAdminCtx, "Prod")
+
+	ds, _ := datastore.FromEnv(datastore.GetCompLogger(), mdAuthorizer, nil)
+	roleMapping := map[string]dbrole.DbRole{
+		SERVICE_AUDITOR: dbrole.READER,
+		SERVICE_ADMIN:   dbrole.WRITER,
+	}
+
+	if err := ds.Register(DevInstanceCtx, roleMapping, &xUser{}); err != nil {
+		log.Fatalf("Failed to create DB tables: %+v", err)
+	}
+
+	// Insert with appropriate Dev Instance Ctx
+	rowsAffected, err := ds.Insert(DevInstanceCtx, p1)
+	fmt.Println(rowsAffected, err)
+
+	// Insert with appropriate Prod Instance Ctx
+	rowsAffected, err = ds.Insert(ProdInstanceCtx, p2)
+	fmt.Println(rowsAffected, err)
+
+	// Insert with appropriate Dev Instance Ctx
+	rowsAffected, err = ds.Insert(DevInstanceCtx, p3)
+	fmt.Println(rowsAffected, err)
+
+	q1 := &xUser{Id: uId}
+	err = ds.Find(DevInstanceCtx, q1)
+	fmt.Println(q1, err)
+
+	q2 := &xUser{Id: uId}
+	err = ds.Find(ProdInstanceCtx, q2)
+	fmt.Println(q2, err)
+
+	// Find using valid Dev Instance Ctx
+	q3 := &xUser{Id: "P3"}
+	err = ds.Find(DevInstanceCtx, q3)
+	fmt.Println(q3, err)
+
+	// Find using invalid Prod Instance Ctx
+	q4 := &xUser{Id: "P3"}
+	err = ds.Find(ProdInstanceCtx, q4)
+	fmt.Println(q4, err)
+
+	rowsAffected, err = ds.Delete(DevInstanceCtx, q1)
+	fmt.Println(rowsAffected, err)
+	rowsAffected, err = ds.Delete(ProdInstanceCtx, q2)
+	fmt.Println(rowsAffected, err)
+	// Delete using valid Dev Instance Ctx
+	rowsAffected, err = ds.Delete(DevInstanceCtx, q3)
+	fmt.Println(rowsAffected, err)
+	// Delete  using invalid Prod Instance Ctx
+	rowsAffected, err = ds.Delete(ProdInstanceCtx, q4)
+	fmt.Println(rowsAffected, err)
+	// Output:
+	// 1 <nil>
+	// 0 SQL statement could not be executed: ERROR: duplicate key value violates unique constraint "x_users_pkey" (SQLSTATE 23505); commit unexpectedly resulted in rollback
+	// 1 <nil>
+	// Bob: 31 <nil>
+	// Bob: 31 <nil>
+	// Pat: 39 <nil>
+	// Pat: 39 <nil>
+	// 1 <nil>
+	// 0 <nil>
+	// 1 <nil>
+	// 0 <nil>
+}

--- a/pkg/datastore/helper.go
+++ b/pkg/datastore/helper.go
@@ -55,7 +55,7 @@ type DBConfig struct {
 	sslMode  string
 }
 
-func FromEnv(l *logrus.Entry, authorizer authorizer.Authorizer) (d DataStore, err error) {
+func FromEnv(l *logrus.Entry, authorizer authorizer.Authorizer, instancer authorizer.Instancer) (d DataStore, err error) {
 	// Ensure all the needed environment variables are present and non-empty
 	for _, envVar := range []string{
 		DB_HOST_ENV_VAR,
@@ -92,10 +92,10 @@ func FromEnv(l *logrus.Entry, authorizer authorizer.Authorizer) (d DataStore, er
 	cfg.dbName = strings.TrimSpace(os.Getenv(DB_NAME_ENV_VAR))
 	cfg.sslMode = strings.TrimSpace(os.Getenv(SSL_MODE_ENV_VAR))
 
-	return FromConfig(l, authorizer, cfg)
+	return FromConfig(l, authorizer, instancer, cfg)
 }
 
-func FromConfig(l *logrus.Entry, authorizer authorizer.Authorizer, cfg DBConfig) (d DataStore, err error) {
+func FromConfig(l *logrus.Entry, authorizer authorizer.Authorizer, instancer authorizer.Instancer, cfg DBConfig) (d DataStore, err error) {
 	gl := GetGormLogger(l)
 	dbConnInitializer := func(db *relationalDb, dbRole dbrole.DbRole) error {
 		db.Lock()
@@ -174,6 +174,7 @@ func FromConfig(l *logrus.Entry, authorizer authorizer.Authorizer, cfg DBConfig)
 	}
 	return &relationalDb{
 		authorizer:  authorizer,
+		instancer:   instancer,
 		gormDBMap:   make(map[dbrole.DbRole]*gorm.DB),
 		initializer: dbConnInitializer,
 		logger:      l,

--- a/pkg/datastore/sql_struct_test.go
+++ b/pkg/datastore/sql_struct_test.go
@@ -126,36 +126,80 @@ func TestSchemaParseFeatures(t *testing.T) {
 		Revision   string `gorm:"-"`
 	}
 
-	// Features by field names
+	// Features using field names
 	type S3 struct {
 		Id         string
 		Name       string
 		OrgId      string
 		InstanceId string
-		Revision   string
+		Revision   int64
 	}
 
-	// Features by golang tags
+	// Features using golang tags
 	type S4 struct {
 		Id            string
 		Name          string
 		TenantId      string `gorm:"primaryKey;column:org_id"`
-		DeploymentId  string `gorm:"column:instance_id"`
-		UpdateVersion string `gorm:"column:revision"`
+		DeploymentId  string `gorm:"primaryKey;column:instance_id"`
+		UpdateVersion int64  `gorm:"column:revision"`
+	}
+
+	// Only Multi-tenancy using golang tags
+	type S5 struct {
+		Id         string
+		Name       string
+		TenantId   string `gorm:"primaryKey;column:org_id"`
+		InstanceId string `gorm:"-"`
+		Revision   int64
+	}
+
+	// Only Multi-instances using field names
+	type S6 struct {
+		Id         string
+		Name       string
+		TenantId   string `gorm:"-"`
+		InstanceId string
 	}
 
 	assert.False(datastore.IsMultiTenanted(S1{}, "S1"))
 	assert.False(datastore.IsMultiTenanted(S2{}, "S2"))
 	assert.True(datastore.IsMultiTenanted(S3{}, "S3"))
 	assert.True(datastore.IsMultiTenanted(S4{}, "S4"))
+	assert.True(datastore.IsMultiTenanted(S5{}, "S5"))
+	assert.False(datastore.IsMultiTenanted(S6{}, "S6"))
 
 	assert.False(datastore.IsRevisioned(S1{}, "S1"))
 	assert.False(datastore.IsRevisioned(S2{}, "S2"))
 	assert.True(datastore.IsRevisioned(S3{}, "S3"))
 	assert.True(datastore.IsRevisioned(S4{}, "S4"))
+	assert.True(datastore.IsRevisioned(S5{}, "S5"))
+	assert.False(datastore.IsRevisioned(S6{}, "S6"))
 
-	assert.False(datastore.IsMultiInstanced(S1{}, "S1"))
-	assert.False(datastore.IsMultiInstanced(S2{}, "S2"))
-	assert.True(datastore.IsMultiInstanced(S3{}, "S3"))
-	assert.True(datastore.IsMultiInstanced(S4{}, "S4"))
+	assert.False(datastore.IsMultiInstanced(S1{}, "S1", true))
+	assert.False(datastore.IsMultiInstanced(S2{}, "S2", true))
+	assert.True(datastore.IsMultiInstanced(S3{}, "S3", true))
+	assert.True(datastore.IsMultiInstanced(S4{}, "S4", true))
+	assert.False(datastore.IsMultiInstanced(S5{}, "S5", true))
+	assert.True(datastore.IsMultiInstanced(S6{}, "S6", true))
+
+	assert.False(datastore.IsMultiInstanced(S1{}, "S1", false))
+	assert.False(datastore.IsMultiInstanced(S2{}, "S2", false))
+	assert.False(datastore.IsMultiInstanced(S3{}, "S3", false))
+	assert.False(datastore.IsMultiInstanced(S4{}, "S4", false))
+	assert.False(datastore.IsMultiInstanced(S5{}, "S5", false))
+	assert.False(datastore.IsMultiInstanced(S6{}, "S6", false))
+
+	assert.False(datastore.IsRowLevelSecurityRequired(S1{}, "S1", true))
+	assert.False(datastore.IsRowLevelSecurityRequired(S2{}, "S2", true))
+	assert.True(datastore.IsRowLevelSecurityRequired(S3{}, "S3", true))
+	assert.True(datastore.IsRowLevelSecurityRequired(S4{}, "S4", true))
+	assert.True(datastore.IsRowLevelSecurityRequired(S5{}, "S5", true))
+	assert.True(datastore.IsRowLevelSecurityRequired(S6{}, "S6", true))
+
+	assert.False(datastore.IsRowLevelSecurityRequired(S1{}, "S1", false))
+	assert.False(datastore.IsRowLevelSecurityRequired(S2{}, "S2", false))
+	assert.True(datastore.IsRowLevelSecurityRequired(S3{}, "S3", false))
+	assert.True(datastore.IsRowLevelSecurityRequired(S4{}, "S4", false))
+	assert.True(datastore.IsRowLevelSecurityRequired(S5{}, "S5", false))
+	assert.False(datastore.IsRowLevelSecurityRequired(S6{}, "S6", false))
 }

--- a/pkg/datastore/transaction_test.go
+++ b/pkg/datastore/transaction_test.go
@@ -38,9 +38,11 @@ func testSingleTableTransactions(t *testing.T) {
 	g2 := &Group{}
 	_ = faker.FakeData(g1)
 	_ = faker.FakeData(g2)
+	g1.InstanceId = AMERICAS
+	g2.InstanceId = AMERICAS
 
 	t.Log("Getting DBTransaction for Groups")
-	tx, err := TestDataStore.GetTransaction(ServiceAdminCtx, g1)
+	tx, err := TestDataStore.GetTransaction(AmericasCokeAdminCtx, g1)
 	assert.NoError(err)
 	t.Log("Creating g1 and g2 in single transaction")
 	err = tx.Transaction(func(tx *gorm.DB) error {
@@ -57,7 +59,7 @@ func testSingleTableTransactions(t *testing.T) {
 	assert.NoError(err)
 	assert.NoError(tx.Error)
 
-	tx, err = TestDataStore.GetTransaction(ServiceAuditorCtx, g1)
+	tx, err = TestDataStore.GetTransaction(AmericasCokeAdminCtx, g1)
 	assert.NoError(err)
 	t.Log("Listing all groups")
 	groups := make([]Group, 0)
@@ -74,7 +76,7 @@ func testSingleTableTransactions(t *testing.T) {
 	assert.Equal(2, len(groups))
 
 	t.Log("Getting DBTransaction for Groups")
-	tx, err = TestDataStore.GetTransaction(ServiceAuditorCtx, g1)
+	tx, err = TestDataStore.GetTransaction(AmericasCokeAuditorCtx, g1)
 	assert.NoError(err)
 
 	t.Log("Finding g1 and g2 in single transaction")
@@ -98,7 +100,7 @@ func testSingleTableTransactions(t *testing.T) {
 	t.Log(g1, g2, f1, f2)
 
 	t.Log("Deleting g1 and g2 in single transaction")
-	tx, err = TestDataStore.GetTransaction(ServiceAdminCtx, g1)
+	tx, err = TestDataStore.GetTransaction(AmericasCokeAdminCtx, g1)
 	assert.NoError(err)
 	err = tx.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Delete(g1).Error; err != nil {
@@ -127,7 +129,7 @@ func testMultiTableTransactions(t *testing.T) {
 	a1.TenantId = COKE
 
 	t.Log("Getting DBTransaction for creating App and AppUser")
-	tx, err := TestDataStore.GetTransaction(CokeAdminCtx, a1, a2)
+	tx, err := TestDataStore.GetTransaction(AmericasCokeAdminCtx, a1, a2)
 	assert.NoError(err)
 	t.Log("Creating App and AppUser in single transaction")
 	err = tx.Transaction(func(tx *gorm.DB) error {
@@ -144,7 +146,7 @@ func testMultiTableTransactions(t *testing.T) {
 	assert.NoError(err)
 	assert.NoError(tx.Error)
 
-	tx, err = TestDataStore.GetTransaction(CokeAuditorCtx, a1, a2)
+	tx, err = TestDataStore.GetTransaction(AmericasCokeAuditorCtx, a1, a2)
 	assert.NoError(err)
 	t.Log("Finding App and Appuser in single transaction")
 	f1, f2 := &App{Id: a1.Id, TenantId: a1.TenantId}, &AppUser{Id: a2.Id}
@@ -194,13 +196,13 @@ func testMultiProtoTransactions(t *testing.T) {
 	a2 := &App{}
 	_ = faker.FakeData(c1)
 	_ = faker.FakeData(a2)
-	a1, err := TestProtoStore.MsgToPersist(CokeAdminCtx, "a1", c1, protostore.Metadata{})
+	a1, err := TestProtoStore.MsgToPersist(AmericasCokeAdminCtx, "a1", c1, protostore.Metadata{})
 	assert.NoError(err)
 	a2.TenantId = COKE
 	t1 := datastore.GetTableName(a1)
 
 	t.Log("Getting DBTransaction for creating pb.Disk and App")
-	tx, err := TestDataStore.GetTransaction(CokeAdminCtx, a1, a2)
+	tx, err := TestDataStore.GetTransaction(AmericasCokeAdminCtx, a1, a2)
 	assert.NoError(err)
 	t.Log("Creating pb.Disk and App in single transaction")
 	err = tx.Transaction(func(tx *gorm.DB) error {
@@ -219,10 +221,10 @@ func testMultiProtoTransactions(t *testing.T) {
 	assert.NoError(err)
 	assert.NoError(tx.Error)
 
-	tx, err = TestDataStore.GetTransaction(CokeAuditorCtx, a1, a2)
+	tx, err = TestDataStore.GetTransaction(AmericasCokeAuditorCtx, a1, a2)
 	assert.NoError(err)
 	t.Log("Finding pb.Disk and App in single transaction")
-	f1, err := TestProtoStore.MsgToFilter(CokeAuditorCtx, "a1", c1)
+	f1, err := TestProtoStore.MsgToFilter(AmericasCokeAuditorCtx, "a1", c1)
 	assert.NoError(err)
 	f2 := &App{Id: a2.Id, TenantId: a2.TenantId}
 	err = tx.Transaction(func(tx *gorm.DB) error {
@@ -247,7 +249,7 @@ func testMultiProtoTransactions(t *testing.T) {
 	t.Log(f1, f2)
 
 	t.Log("Deleting pb.Disk and App in single transaction")
-	tx, err = TestDataStore.GetTransaction(ServiceAdminCtx, a1)
+	tx, err = TestDataStore.GetTransaction(AmericasCokeAdminCtx, a1)
 	assert.NoError(err)
 	err = tx.Transaction(func(tx *gorm.DB) error {
 		t.Logf("Deleting %+v", a1)
@@ -267,9 +269,9 @@ func testMultiProtoTransactions(t *testing.T) {
 	assert.NoError(tx.Error)
 
 	t.Log("Finding pb.Disk and App after delete should return error")
-	tx, err = TestDataStore.GetTransaction(ServiceAdminCtx, a1)
+	tx, err = TestDataStore.GetTransaction(AmericasCokeAdminCtx, a1)
 	assert.NoError(err)
-	f1, err = TestProtoStore.MsgToFilter(CokeAuditorCtx, "a1", c1)
+	f1, err = TestProtoStore.MsgToFilter(AmericasCokeAuditorCtx, "a1", c1)
 	assert.NoError(err)
 	f2 = &App{Id: a2.Id, TenantId: a2.TenantId}
 	err = tx.Transaction(func(tx *gorm.DB) error {

--- a/pkg/errors/error_codes.go
+++ b/pkg/errors/error_codes.go
@@ -172,7 +172,7 @@ var (
 	ErrRevisionConflict    = ErrBaseDb.With("Blocking update due to outdated revision")
 	ErrMarshalling         = ErrBaseDb.With("Cannot marshal proto message to binary")
 	ErrUnmarshalling       = ErrBaseDb.With("Cannot unmarshal binary to proto message")
-	ErrOperationNotAllowed = ErrBaseDb.With("Not authorized to perform the operation on other tenant's data")
+	ErrOperationNotAllowed = ErrBaseDb.With("Not authorized to perform the operation on other's data")
 	ErrFetchingMetadata    = ErrBaseDb.With("Error fetching metadata from GRPC context")
 	ErrTableDoesNotExist   = ErrBaseDb.With("Table does not exist")
 	ErrRecordNotFound      = ErrBaseDb.With("Record not found")

--- a/pkg/protostore/protostore.go
+++ b/pkg/protostore/protostore.go
@@ -117,6 +117,7 @@ type ProtoStoreMsg struct {
 	ParentId   string
 	Revision   int64
 	OrgId      string `gorm:"primaryKey"`
+	InstanceId string `gorm:"primaryKey"`
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 	XTableName string `gorm:"-"`
@@ -474,9 +475,15 @@ func (p ProtobufDataStore) MsgToFilter(ctx context.Context, id string, msg proto
 		return &ProtoStoreMsg{}, err
 	}
 
+	instanceId, err := p.ds.GetInstancer().GetInstanceId(ctx)
+	if err != nil {
+		return &ProtoStoreMsg{}, err
+	}
+
 	return &ProtoStoreMsg{
 		Id:         id,
 		OrgId:      orgId,
+		InstanceId: instanceId,
 		XTableName: datastore.GetTableName(msg),
 	}, nil
 }

--- a/pkg/protostore/protostore_test.go
+++ b/pkg/protostore/protostore_test.go
@@ -171,7 +171,7 @@ func setupDbContext(t *testing.T) {
 
 func TestProtoStoreInDbFindWithInvalidParams(t *testing.T) {
 	setupDbContext(t)
-	testProtoStoreFindWithInvalidParams(t, PepsiAdminCtx)
+	testProtoStoreFindWithInvalidParams(t, AmericasPepsiAdminCtx)
 }
 
 /*
@@ -241,7 +241,7 @@ func testProtoStoreFindWithInvalidParams(t *testing.T, ctx context.Context) {
 
 func TestProtoStoreInDbFindAll(t *testing.T) {
 	setupDbContext(t)
-	testProtoStoreFindAll(t, PepsiAdminCtx)
+	testProtoStoreFindAll(t, AmericasPepsiAdminCtx)
 }
 
 /*
@@ -499,13 +499,13 @@ func testProtoStoreFindAll(t *testing.T, ctx context.Context) {
 
 func TestProtoStoreInDbCrud(t *testing.T) {
 	setupDbContext(t)
-	testProtoStoreCrud(t, PepsiAdminCtx, false)
+	testProtoStoreCrud(t, AmericasPepsiAdminCtx, false)
 }
 
 // Same as TestProtoStoreInDbCrud, but uses Upsert instead of Insert or Update.
 func TestProtoStoreInDbCrudUpsert(t *testing.T) {
 	setupDbContext(t)
-	testProtoStoreCrud(t, PepsiAdminCtx, true)
+	testProtoStoreCrud(t, AmericasPepsiAdminCtx, true)
 }
 
 /*
@@ -671,15 +671,15 @@ func TestProtoStoreInDbMultitenancy(t *testing.T) {
 
 	cpuMsg1 := pb.CPU{}
 	_ = faker.FakeData(&cpuMsg1)
-	rowsAffected, md, err := p.Insert(PepsiAdminCtx, cpuMsg1.Name, &cpuMsg1) // Pepsi inserts a record into Protostore
+	rowsAffected, md, err := p.Insert(AmericasPepsiAdminCtx, cpuMsg1.Name, &cpuMsg1) // Pepsi inserts a record into Protostore
 	assert.NoError(err)
 	assert.Equal(int64(1), rowsAffected)
 	assert.Equal(cpuMsg1.Name, md.Id)
 	assert.Equal(int64(1), md.Revision)
 
 	queryResult := pb.CPU{}
-	err = p.FindById(CokeAdminCtx, cpuMsg1.Name, &queryResult, nil) // Coke tries to read Pepsi's Protobuf message
-	assert.ErrorIs(err, ErrRecordNotFound)                          // Coke won't be able to see that record due to RLS
+	err = p.FindById(AmericasCokeAdminCtx, cpuMsg1.Name, &queryResult, nil) // Coke tries to read Pepsi's Protobuf message
+	assert.ErrorIs(err, ErrRecordNotFound)                                  // Coke won't be able to see that record due to RLS
 	assert.Empty(queryResult.GetName(), "Coke user found a record belonging to Pepsi tenant")
 }
 
@@ -689,7 +689,7 @@ func BenchmarkCrudProtoStoreInDb(b *testing.B) {
 	var t testing.T
 	setupDbContext(&t)
 	for n := 0; n < b.N; n++ {
-		testProtoStoreCrud(&t, CokeAdminCtx, false)
-		testProtoStoreCrud(&t, CokeAdminCtx, true)
+		testProtoStoreCrud(&t, AmericasCokeAdminCtx, false)
+		testProtoStoreCrud(&t, AmericasCokeAdminCtx, true)
 	}
 }

--- a/test/data.go
+++ b/test/data.go
@@ -26,12 +26,14 @@ import (
 	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/protostore"
 )
 
-// Organizations.
 const (
+	// Organizations.
 	COKE  = "Coke"
 	PEPSI = "Pepsi"
 
-	AMERICAS = "americas"
+	// Instances.
+	AMERICAS = "Americas"
+	EUROPE   = "Europe"
 )
 
 // Service roles for test cases.
@@ -45,6 +47,7 @@ const (
 var (
 	RANDOM_ID              string = uuid.New().String()
 	TestMetadataAuthorizer        = authorizer.MetadataBasedAuthorizer{}
+	TestInstancer                 = authorizer.SimpleInstancer{}
 	ServiceAdminCtx               = TestMetadataAuthorizer.GetAuthContext("", SERVICE_ADMIN)
 	ServiceAuditorCtx             = TestMetadataAuthorizer.GetAuthContext("", SERVICE_AUDITOR)
 	CokeAdminCtx                  = TestMetadataAuthorizer.GetAuthContext(COKE, TENANT_ADMIN)
@@ -52,7 +55,13 @@ var (
 	PepsiAdminCtx                 = TestMetadataAuthorizer.GetAuthContext(PEPSI, TENANT_ADMIN)
 	PepsiAuditorCtx               = TestMetadataAuthorizer.GetAuthContext(PEPSI, TENANT_AUDITOR)
 
-	TestDataStore, _ = datastore.FromEnv(datastore.GetCompLogger(), TestMetadataAuthorizer)
+	AmericasCokeAdminCtx   = TestInstancer.WithInstanceId(CokeAdminCtx, AMERICAS)
+	AmericasCokeAuditorCtx = TestInstancer.WithInstanceId(CokeAuditorCtx, AMERICAS)
+	AmericasPepsiAdminCtx  = TestInstancer.WithInstanceId(PepsiAdminCtx, AMERICAS)
+	EuropeCokeAdminCtx     = TestInstancer.WithInstanceId(CokeAdminCtx, EUROPE)
+	EuropeCokeAuditorCtx   = TestInstancer.WithInstanceId(CokeAuditorCtx, EUROPE)
+
+	TestDataStore, _ = datastore.FromEnv(datastore.GetCompLogger(), TestMetadataAuthorizer, TestInstancer)
 	TestProtoStore   = protostore.GetProtoStore(datastore.GetCompLogger(), TestDataStore)
 )
 
@@ -99,7 +108,8 @@ func (a App) AreNonKeyFieldsEmpty() bool {
 }
 
 type Group struct {
-	Id       string
-	Name     string
-	Revision int
+	Id         string `gorm:"primaryKey"`
+	Name       string
+	Revision   int
+	InstanceId string `gorm:"primaryKey"`
 }


### PR DESCRIPTION
- instance_id would be treated as the column used for scoping
the view of different instances in the datastore
- Added unit-tests for data with instanceid for datastore and protostore