### PR TITLE
 Support context based transaction for create/update only

### DIFF
--- a/build/install_tools.sh
+++ b/build/install_tools.sh
@@ -3,26 +3,51 @@ set -eux
 
 source $(dirname "$0")/env.sh
 
+FORCE=false
+GODLV_VERSION=${GODLV_VERSION:=1.21.0}
 if go version | grep 1.2; then
-  GOLNT_VERSION=${GOLNT_VERSION:=v1.52.2}
+  GOLNT_VERSION=${GOLNT_VERSION:=1.52.2}
 else
-  GOLNT_VERSION=${GOLNT_VERSION:=v1.50.1}
+  GOLNT_VERSION=${GOLNT_VERSION:=1.50.1}
 fi
-GOMRK_VERSION=v1.1.0
-SHFMT_VERSION=v3.6.0
-TYPOS_VERSION=1.13.6
+GOMRK_VERSION=${GOMRK_VERSION:=1.1.0}
+SHFMT_VERSION=${SHFMT_VERSION:=3.6.0}
+GOIMP_VERSION=${GOIMP_VERSION:=0.5.0}
+GOIMPORTS_REVISER_VERSION=${GOIMPORTS_REVISER_VERSION:=3.4.2}
+TYPOS_VERSION=${TYPOS_VERSION:=1.13.6}
+ADDLICENSE_VERSION=${ADDLICENSE_VERSION:=1.1.1}
+CODEOWNERS_VALIDATOR_VERSION=${CODEOWNERS_VALIDATOR_VERSION:=0.7.4}
+YAMLFMT_VERSION=${YAMLFMT_VERSION:=0.9.0}
 
-go-licenser -version || go install github.com/elastic/go-licenser@latest
-$(go env GOPATH)/bin/shfmt -version | grep ${SHFMT_VERSION} || go install mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}
-$(go env GOPATH)/bin/gomarkdoc --version | grep ${GOMRK_VERSION} || go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@${GOMRK_VERSION}
-$(go env GOPATH)/bin/golangci-lint version | grep ${GOLNT_VERSION} || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLNT_VERSION}
-go install -v github.com/incu6us/goimports-reviser/v3@latest
+# With version check
+go_install() {
+  ([ ${FORCE} = false ] && $1 | grep $2) || go install $3@v$2
+}
 
-if [[ "${OSTYPE}" == "linux"* ]]; then
+# Without version check
+go_install_any() {
+  ([ ${FORCE} = false ] && $1 >/dev/null 2>&1) || go install $2@$3
+}
+
+go version | grep '1.19\|1.20\|1.21' || (
+  echo "Install supported version (>=1.19) of golang to use saas-ci"
+  exit 1
+)
+go_install "dlv version" ${GODLV_VERSION} github.com/go-delve/delve/cmd/dlv
+go_install "golangci-lint version" ${GOLNT_VERSION} github.com/golangci/golangci-lint/cmd/golangci-lint
+go_install "gomarkdoc --version" ${GOMRK_VERSION} github.com/princjef/gomarkdoc/cmd/gomarkdoc
+go_install "shfmt -version" ${SHFMT_VERSION} mvdan.cc/sh/v3/cmd/shfmt
+go_install_any "goimports -h" golang.org/x/tools/cmd/goimports v${GOIMP_VERSION}
+go_install_any "goimports-reviser -h" "github.com/incu6us/goimports-reviser/v3" v${GOIMPORTS_REVISER_VERSION}
+go_install_any "golicenser -version" github.com/elastic/go-licenser latest
+go_install_any "addlicense -h" github.com/google/addlicense v${ADDLICENSE_VERSION}
+go_install_any "codeowners-validator -v" github.com/mszostok/codeowners-validator v${CODEOWNERS_VALIDATOR_VERSION}
+go_install_any "yamlfmt -h" github.com/google/yamlfmt/cmd/yamlfmt v${YAMLFMT_VERSION}
+
+OS_TYPE=$(uname -s)
+if [ "${OS_TYPE}" = "Linux" ]; then
   /tmp/typos --version | grep ${TYPOS_VERSION} || wget -qO- https://github.com/crate-ci/typos/releases/download/v${TYPOS_VERSION}/typos-v${TYPOS_VERSION}-x86_64-unknown-linux-musl.tar.gz | tar -zxf - -C /tmp/ ./typos
-  sudo snap install mdl
-elif [[ "${OSTYPE}" == "darwin"* ]]; then
+elif [ "${OS_TYPE}" = "Darwin" ]; then
   /tmp/typos --version | grep ${TYPOS_VERSION} || wget -qO- https://github.com/crate-ci/typos/releases/download/v${TYPOS_VERSION}/typos-v${TYPOS_VERSION}-x86_64-apple-darwin.tar.gz | tar -zxf - -C /tmp/ ./typos
 fi
-
 pip3 install addlicense mdv yamllint

--- a/pkg/authorizer/transaction.go
+++ b/pkg/authorizer/transaction.go
@@ -1,0 +1,38 @@
+package authorizer
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+type TransactionContextKey string
+
+const (
+	TransactionCtx = TransactionContextKey("DB_TRANSACTION")
+)
+
+type TransactionFetcher interface {
+	IsTransactionCtx(ctx context.Context) bool
+	GetTransactionCtx(ctx context.Context) *gorm.DB
+	WithTransactionCtx(ctx context.Context, tx *gorm.DB) context.Context
+}
+
+type SimpleTransactionFetcher struct{}
+
+func (s SimpleTransactionFetcher) GetTransactionCtx(ctx context.Context) *gorm.DB {
+	if v := ctx.Value(TransactionCtx); v != nil {
+		if dbTx, ok := v.(*gorm.DB); ok {
+			return dbTx
+		}
+	}
+	return nil
+}
+
+func (s SimpleTransactionFetcher) WithTransactionCtx(ctx context.Context, tx *gorm.DB) context.Context {
+	return context.WithValue(ctx, TransactionCtx, tx)
+}
+
+func (s SimpleTransactionFetcher) IsTransactionCtx(ctx context.Context) bool {
+	return s.GetTransactionCtx(ctx) != nil
+}

--- a/pkg/datastore/datastore_with_txcontext_test.go
+++ b/pkg/datastore/datastore_with_txcontext_test.go
@@ -1,0 +1,140 @@
+// Copyright 2023 VMware, Inc.
+// Licensed to VMware, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. VMware, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package datastore_test
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+
+	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/authorizer"
+	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/datastore"
+	. "github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/errors"
+	. "github.com/vmware-labs/multi-tenant-persistence-for-saas/test"
+)
+
+func rollbackTx(t *testing.T, tx *gorm.DB) {
+	t.Helper()
+	if err := tx.Rollback().Error; err != nil && err != sql.ErrTxDone {
+		t.Log("Rollback of tx errored", err)
+	}
+}
+
+func testTxCrud(t *testing.T, ds datastore.DataStore, ctx context.Context, myCokeApp *App, user1, user2 *AppUser) {
+	t.Helper()
+	assert := assert.New(t)
+	var err error
+
+	txFetcher := authorizer.SimpleTransactionFetcher{}
+
+	// Querying of previously inserted records should succeed
+	for _, record := range []*AppUser{user1, user2} {
+		queryResult := AppUser{Id: record.Id}
+		err = ds.Find(ctx, &queryResult)
+		assert.NoError(err)
+		assert.Equal(record, &queryResult)
+	}
+
+	// Updating non-key fields in a record should succeed
+	user1.Name = "Jeyhun G."
+	user1.Email = "jeyhun111@mail.com"
+	user1.EmailConfirmed = !user1.EmailConfirmed
+	user1.NumFollowers++
+	user2.Name = "Jahangir G."
+	user2.Email = "jahangir111@mail.com"
+	user2.EmailConfirmed = !user2.EmailConfirmed
+	user2.NumFollowers--
+
+	// TODO: Find, Update and Delete are still not supported due to appending where clauses,
+	// after each call to Find/Update/Delete methods
+
+	tx, err := ds.Helper().GetDBTransaction(ctx, datastore.GetTableName(user1), user1)
+	assert.NoError(err)
+	defer rollbackTx(t, tx)
+	txCtx := txFetcher.WithTransactionCtx(ctx, tx)
+	for _, record := range []*AppUser{user1, user2} {
+		rowsAffected, err := ds.Upsert(txCtx, record)
+		assert.NoError(err)
+		assert.EqualValues(1, rowsAffected)
+	}
+	assert.NoError(tx.Commit().Error)
+
+	for _, record := range []*AppUser{user1, user2} {
+		queryResult := &AppUser{Id: record.Id}
+		err = ds.Find(ctx, queryResult)
+		assert.NoError(err)
+		assert.Equal(record, queryResult)
+	}
+
+	tx, err = ds.Helper().GetDBTransaction(ctx, datastore.GetTableName(user1), user1)
+	assert.NoError(err)
+	defer rollbackTx(t, tx)
+	txCtx = txFetcher.WithTransactionCtx(ctx, tx)
+	// Upsert operation should be an update for already existing records
+	user1.NumFollowers++
+	user2.NumFollowers--
+	for _, record := range []*AppUser{user1, user2} {
+		rowsAffected, err := ds.Upsert(txCtx, record)
+		assert.NoError(err)
+		assert.EqualValues(1, rowsAffected)
+	}
+	assert.NoError(tx.Commit().Error)
+	for _, record := range []*AppUser{user1, user2} {
+		queryResult := &AppUser{Id: record.Id}
+		err = ds.Find(ctx, queryResult)
+		assert.NoError(err)
+		assert.Equal(record, queryResult)
+	}
+
+	// Deletion of existing records should not fail, and the records should no longer be found in the DB
+	for _, record := range []*AppUser{user1, user2} {
+		rowsAffected, err := ds.Delete(ctx, record)
+		assert.NoError(err)
+		assert.EqualValues(1, rowsAffected)
+		queryResult := AppUser{Id: record.Id}
+		err = ds.Find(ctx, &queryResult)
+		assert.ErrorIs(err, ErrRecordNotFound)
+		assert.True(queryResult.AreNonKeyFieldsEmpty())
+	}
+}
+
+func BenchmarkTxCrud(b *testing.B) {
+	logger := datastore.GetLogger()
+	logger.SetLevel(logrus.FatalLevel)
+	logger.SetOutput(io.Discard)
+	LOG = logger.WithField(datastore.COMP, datastore.SAAS_PERSISTENCE)
+
+	var t testing.T
+	ds, _ := SetupDataStore("BenchmarkCrud")
+	myCokeApp, user1, user2 := SetupDbTables(ds)
+	for n := 0; n < b.N; n++ {
+		testCrud(&t, ds, CokeAdminCtx, myCokeApp, user1, user2)
+	}
+}
+
+func TestTxCrud(t *testing.T) {
+	ds, _ := SetupDataStore("TestTxCrud")
+	myCokeApp, user1, user2 := SetupDbTables(ds)
+	testTxCrud(t, ds, CokeAdminCtx, myCokeApp, user1, user2)
+}

--- a/pkg/datastore/helper.go
+++ b/pkg/datastore/helper.go
@@ -97,11 +97,11 @@ func ConfigFromEnv(dbName string) DBConfig {
 	return cfg
 }
 
-func FromEnv(l *logrus.Entry, authorizer authorizer.Authorizer, instancer authorizer.Instancer) (d DataStore, err error) {
-	return FromConfig(l, authorizer, instancer, ConfigFromEnv(""))
+func FromEnv(l *logrus.Entry, a authorizer.Authorizer, instancer authorizer.Instancer) (d DataStore, err error) {
+	return FromConfig(l, a, instancer, ConfigFromEnv(""))
 }
 
-func FromConfig(l *logrus.Entry, authorizer authorizer.Authorizer, instancer authorizer.Instancer, cfg DBConfig) (d DataStore, err error) {
+func FromConfig(l *logrus.Entry, a authorizer.Authorizer, instancer authorizer.Instancer, cfg DBConfig) (d DataStore, err error) {
 	gl := GetGormLogger(l)
 	dbConnInitializer := func(db *relationalDb, dbRole dbrole.DbRole) error {
 		db.Lock()
@@ -180,11 +180,12 @@ func FromConfig(l *logrus.Entry, authorizer authorizer.Authorizer, instancer aut
 	}
 	return &relationalDb{
 		dbName:      cfg.dbName,
-		authorizer:  authorizer,
+		authorizer:  a,
 		instancer:   instancer,
 		gormDBMap:   make(map[dbrole.DbRole]*gorm.DB),
 		initializer: dbConnInitializer,
 		logger:      l,
+		txFetcher:   authorizer.SimpleTransactionFetcher{},
 	}, nil
 }
 

--- a/test/helper.go
+++ b/test/helper.go
@@ -32,7 +32,6 @@ func SetupDataStore(dbName string) (datastore.DataStore, protostore.ProtoStore) 
 	if err != nil {
 		log.Fatalf("Failed to create database from cfg %+v", cfg)
 	}
-	log.Printf("Created/Exists database %s", dbName)
 	ds, err := datastore.FromConfig(datastore.GetCompLogger(), TestMetadataAuthorizer, TestInstancer, cfg)
 	if err != nil {
 		log.Fatalf("Failed to initialize datastore from cfg %+v", cfg)


### PR DESCRIPTION
MR details - 

Changes for exposing transactions outside datastore CRUD methods.

- Currently, transaction support is only available to create/upsert methods.
- Update/Delete/Find still doesn't support them due to chaining of the
where clauses

Git issue link - https://github.com/vmware-labs/multi-tenant-persistence-for-saas/issues/49#issue-1801643594