### PR TITLE
Stop printing Protobuf message and its metadata in logs

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -533,7 +533,7 @@ func main() {
 	// Attempts to find a record using the incorrect context of the Prod instance and should error out.
 	q4 := &Person{Id: "P3"}
 	err = ds.Find(ProdInstanceCtx, q4)
-	fmt.Println(err)
+	fmt.Printf("err != nil - %t\n", err != nil)
 
 	// Deletes a record using the context of the Dev instance and the specified uId.
 	rowsAffected, err = ds.Delete(DevInstanceCtx, q1)
@@ -559,8 +559,7 @@ func main() {
 [Dev/P1337] Bob: 31 <nil>
 [Prod/P1337] John: 36 <nil>
 [Dev/P3] Pat: 39 <nil>
-Unable to locate record [record=[/P3] : 0, dbName=postgres]
-	record not found
+err != nil - true
 1 <nil>
 1 <nil>
 0 <nil>
@@ -653,7 +652,7 @@ func main() {
 	// Attempts to find a record using the incorrect context of the Pepsi organization and should error out.
 	q4 := &User{Id: "P3"}
 	err = ds.Find(PepsiOrgCtx, q4)
-	fmt.Println(err)
+	fmt.Printf("err != nil - %t\n", err != nil)
 
 	// Deletes a record using the context of the Coke organization and the specified uId.
 	rowsAffected, err = ds.Delete(CokeOrgCtx, q1)
@@ -680,8 +679,7 @@ func main() {
 [Coke/P1337] Bob: 31 <nil>
 [Pepsi/P1337] John: 36 <nil>
 [Coke/P3] Pat: 39 <nil>
-Unable to locate record [record=[/P3] : 0, dbName=postgres]
-	record not found
+err != nil - true
 1 <nil>
 1 <nil>
 0 <nil>
@@ -1028,6 +1026,7 @@ This package exposes interface \[pkg.protostore.ProtoStore\] to the consumer, wh
 - [type ProtoStore](<#type-protostore>)
   - [func GetProtoStore(logger *logrus.Entry, ds datastore.DataStore) ProtoStore](<#func-getprotostore>)
 - [type ProtoStoreMsg](<#type-protostoremsg>)
+  - [func (msg *ProtoStoreMsg) String() string](<#func-protostoremsg-string>)
   - [func (msg *ProtoStoreMsg) TableName() string](<#func-protostoremsg-tablename>)
 - [type ProtobufDataStore](<#type-protobufdatastore>)
   - [func (p ProtobufDataStore) DeleteById(ctx context.Context, id string, msg proto.Message) (int64, error)](<#func-protobufdatastore-deletebyid>)
@@ -1050,19 +1049,19 @@ This package exposes interface \[pkg.protostore.ProtoStore\] to the consumer, wh
   - [func (p ProtobufDataStore) UpsertWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (rowsAffected int64, md Metadata, err error)](<#func-protobufdatastore-upsertwithmetadata>)
 
 
-## func [FromBytes](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L95>)
+## func [FromBytes](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L108>)
 
 ```go
 func FromBytes(bytes []byte, message proto.Message) error
 ```
 
-## func [ToBytes](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L103>)
+## func [ToBytes](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L116>)
 
 ```go
 func ToBytes(message proto.Message) ([]byte, error)
 ```
 
-## type [Metadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L69-L76>)
+## type [Metadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L70-L77>)
 
 ```go
 type Metadata struct {
@@ -1075,13 +1074,13 @@ type Metadata struct {
 }
 ```
 
-### func [MetadataFrom](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L111>)
+### func [MetadataFrom](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L124>)
 
 ```go
 func MetadataFrom(protoStoreMsg ProtoStoreMsg) Metadata
 ```
 
-## type [ProtoStore](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L44-L67>)
+## type [ProtoStore](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L45-L68>)
 
 ```go
 type ProtoStore interface {
@@ -1193,36 +1192,42 @@ DeleteById:: rowsAffected: 1 err: <nil>
 </p>
 </details>
 
-### func [GetProtoStore](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L127>)
+### func [GetProtoStore](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L140>)
 
 ```go
 func GetProtoStore(logger *logrus.Entry, ds datastore.DataStore) ProtoStore
 ```
 
-## type [ProtoStoreMsg](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L78-L89>)
+## type [ProtoStoreMsg](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L79-L90>)
 
 ```go
 type ProtoStoreMsg struct {
-    Id         string `gorm:"primaryKey"`
-    Msg        []byte
-    ParentId   string
-    Revision   int64
-    OrgId      string `gorm:"primaryKey"`
-    InstanceId string `gorm:"primaryKey"`
-    CreatedAt  time.Time
-    UpdatedAt  time.Time
-    DeletedAt  gorm.DeletedAt
-    XTableName string `gorm:"-"`
+    Id         string         `gorm:"primaryKey" json:"id"`
+    Msg        []byte         `json:"-"`
+    ParentId   string         `json:"parent_id,omitempty"`
+    Revision   int64          `json:"revision"`
+    OrgId      string         `gorm:"primaryKey" json:"org_id"`
+    InstanceId string         `gorm:"primaryKey" json:"instance_id,omitempty"`
+    CreatedAt  time.Time      `json:"-"`
+    UpdatedAt  time.Time      `json:"-"`
+    DeletedAt  gorm.DeletedAt `json:"-"`
+    XTableName string         `gorm:"-" json:"x_table_name"`
 }
 ```
 
-### func \(\*ProtoStoreMsg\) [TableName](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L91>)
+### func \(\*ProtoStoreMsg\) [String](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L96>)
+
+```go
+func (msg *ProtoStoreMsg) String() string
+```
+
+### func \(\*ProtoStoreMsg\) [TableName](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L92>)
 
 ```go
 func (msg *ProtoStoreMsg) TableName() string
 ```
 
-## type [ProtobufDataStore](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L122-L125>)
+## type [ProtobufDataStore](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L135-L138>)
 
 ```go
 type ProtobufDataStore struct {
@@ -1230,19 +1235,19 @@ type ProtobufDataStore struct {
 }
 ```
 
-### func \(ProtobufDataStore\) [DeleteById](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L406>)
+### func \(ProtobufDataStore\) [DeleteById](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L419>)
 
 ```go
 func (p ProtobufDataStore) DeleteById(ctx context.Context, id string, msg proto.Message) (int64, error)
 ```
 
-### func \(ProtobufDataStore\) [DropTables](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L414>)
+### func \(ProtobufDataStore\) [DropTables](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L427>)
 
 ```go
 func (p ProtobufDataStore) DropTables(msgs ...proto.Message) error
 ```
 
-### func \(ProtobufDataStore\) [FindAll](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L349>)
+### func \(ProtobufDataStore\) [FindAll](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L362>)
 
 ```go
 func (p ProtobufDataStore) FindAll(ctx context.Context, msgs interface{}, pagination *datastore.Pagination) (metadataMap map[string]Metadata, err error)
@@ -1250,13 +1255,13 @@ func (p ProtobufDataStore) FindAll(ctx context.Context, msgs interface{}, pagina
 
 FindAll Finds all messages \(of the same type as the element of msgs\) in Protostore and stores the result in msgs. msgs must be a pointer to a slice of Protobuf structs or a pointer to a slice of pointers to Protobuf structs. It will be modified in\-place. Returns a map of Protobuf messages' IDs to their metadata \(parent ID & revision\).
 
-### func \(ProtobufDataStore\) [FindAllAsMap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L291>)
+### func \(ProtobufDataStore\) [FindAllAsMap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L304>)
 
 ```go
 func (p ProtobufDataStore) FindAllAsMap(ctx context.Context, msgsMap interface{}, pagination *datastore.Pagination) (metadataMap map[string]Metadata, err error)
 ```
 
-### func \(ProtobufDataStore\) [FindById](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L257>)
+### func \(ProtobufDataStore\) [FindById](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L270>)
 
 ```go
 func (p ProtobufDataStore) FindById(ctx context.Context, id string, msg proto.Message, metadata *Metadata) error
@@ -1264,25 +1269,25 @@ func (p ProtobufDataStore) FindById(ctx context.Context, id string, msg proto.Me
 
 Finds a Protobuf message by ID. If metadata arg. is non\-nil, fills it with the metadata \(parent ID & revision\) of the Protobuf message that was found.
 
-### func \(ProtobufDataStore\) [GetAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L135>)
+### func \(ProtobufDataStore\) [GetAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L148>)
 
 ```go
 func (p ProtobufDataStore) GetAuthorizer() authorizer.Authorizer
 ```
 
-### func \(ProtobufDataStore\) [GetMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L273>)
+### func \(ProtobufDataStore\) [GetMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L286>)
 
 ```go
 func (p ProtobufDataStore) GetMetadata(ctx context.Context, id string, msg proto.Message) (md Metadata, err error)
 ```
 
-### func \(ProtobufDataStore\) [GetRevision](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L282>)
+### func \(ProtobufDataStore\) [GetRevision](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L295>)
 
 ```go
 func (p ProtobufDataStore) GetRevision(ctx context.Context, id string, msg proto.Message) (int64, error)
 ```
 
-### func \(ProtobufDataStore\) [Insert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L152>)
+### func \(ProtobufDataStore\) [Insert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L165>)
 
 ```go
 func (p ProtobufDataStore) Insert(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error)
@@ -1290,7 +1295,7 @@ func (p ProtobufDataStore) Insert(ctx context.Context, id string, msg proto.Mess
 
 @DEPRECATED See \[InsertWithMetadata\].
 
-### func \(ProtobufDataStore\) [InsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L161>)
+### func \(ProtobufDataStore\) [InsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L174>)
 
 ```go
 func (p ProtobufDataStore) InsertWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (rowsAffected int64, md Metadata, err error)
@@ -1298,7 +1303,7 @@ func (p ProtobufDataStore) InsertWithMetadata(ctx context.Context, id string, ms
 
 Inserts a new Protobuf record in the DB. Returns, rowsAffected \- 0 if insertion fails; 1 otherwise md \- metadata of the new Protobuf record err \- error that occurred during insertion, if any.
 
-### func \(ProtobufDataStore\) [MsgToFilter](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L446>)
+### func \(ProtobufDataStore\) [MsgToFilter](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L459>)
 
 ```go
 func (p ProtobufDataStore) MsgToFilter(ctx context.Context, id string, msg proto.Message) (pMsg *ProtoStoreMsg, err error)
@@ -1306,7 +1311,7 @@ func (p ProtobufDataStore) MsgToFilter(ctx context.Context, id string, msg proto
 
 Return the ProtoStoreMsg that can be used for filtering with id/orgId filled up and error that occurred during extraction orgId from context.
 
-### func \(ProtobufDataStore\) [MsgToPersist](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L427>)
+### func \(ProtobufDataStore\) [MsgToPersist](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L440>)
 
 ```go
 func (p ProtobufDataStore) MsgToPersist(ctx context.Context, id string, msg proto.Message, md Metadata) (pMsg *ProtoStoreMsg, err error)
@@ -1314,19 +1319,19 @@ func (p ProtobufDataStore) MsgToPersist(ctx context.Context, id string, msg prot
 
 Return the serialized ProtoStoreMsg that can be persisted to database and error that occurred during extraction orgId from context, or serialization.
 
-### func \(ProtobufDataStore\) [Register](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L139>)
+### func \(ProtobufDataStore\) [Register](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L152>)
 
 ```go
 func (p ProtobufDataStore) Register(ctx context.Context, roleMapping map[string]dbrole.DbRole, msgs ...proto.Message) error
 ```
 
-### func \(ProtobufDataStore\) [SoftDeleteById](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L398>)
+### func \(ProtobufDataStore\) [SoftDeleteById](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L411>)
 
 ```go
 func (p ProtobufDataStore) SoftDeleteById(ctx context.Context, id string, msg proto.Message) (int64, error)
 ```
 
-### func \(ProtobufDataStore\) [Update](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L185>)
+### func \(ProtobufDataStore\) [Update](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L198>)
 
 ```go
 func (p ProtobufDataStore) Update(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error)
@@ -1334,7 +1339,7 @@ func (p ProtobufDataStore) Update(ctx context.Context, id string, msg proto.Mess
 
 Update Fetches metadata for the record and updates the Protobuf message. NOTE: Avoid using this method in user\-workflows and only in service\-to\-service workflows when the updates are already ordered by some other service/app.
 
-### func \(ProtobufDataStore\) [UpdateWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L198>)
+### func \(ProtobufDataStore\) [UpdateWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L211>)
 
 ```go
 func (p ProtobufDataStore) UpdateWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (rowsAffected int64, md Metadata, err error)
@@ -1342,7 +1347,7 @@ func (p ProtobufDataStore) UpdateWithMetadata(ctx context.Context, id string, ms
 
 Updates an existing Protobuf record in the DB. Returns, rowsAffected \- 0 if update fails; 1 otherwise md \- metadata of the updated Protobuf record err \- error that occurred during update, if any.
 
-### func \(ProtobufDataStore\) [Upsert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L217>)
+### func \(ProtobufDataStore\) [Upsert](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L230>)
 
 ```go
 func (p ProtobufDataStore) Upsert(ctx context.Context, id string, msg proto.Message) (rowsAffected int64, md Metadata, err error)
@@ -1350,7 +1355,7 @@ func (p ProtobufDataStore) Upsert(ctx context.Context, id string, msg proto.Mess
 
 Upsert Fetches metadata for the record and upserts the Protobuf message. NOTE: Avoid using this method in user\-workflows and only in service\-to\-service workflows when the updates are already ordered by some other service/app.
 
-### func \(ProtobufDataStore\) [UpsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L235-L237>)
+### func \(ProtobufDataStore\) [UpsertWithMetadata](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/protostore/protostore.go#L248-L250>)
 
 ```go
 func (p ProtobufDataStore) UpsertWithMetadata(ctx context.Context, id string, msg proto.Message, metadata Metadata) (rowsAffected int64, md Metadata, err error)

--- a/pkg/protostore/protostore.go
+++ b/pkg/protostore/protostore.go
@@ -26,6 +26,7 @@ package protostore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -76,20 +77,32 @@ type Metadata struct {
 }
 
 type ProtoStoreMsg struct {
-	Id         string `gorm:"primaryKey"`
-	Msg        []byte
-	ParentId   string
-	Revision   int64
-	OrgId      string `gorm:"primaryKey"`
-	InstanceId string `gorm:"primaryKey"`
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
-	DeletedAt  gorm.DeletedAt
-	XTableName string `gorm:"-"`
+	Id         string         `gorm:"primaryKey" json:"id"`
+	Msg        []byte         `json:"-"`
+	ParentId   string         `json:"parent_id,omitempty"`
+	Revision   int64          `json:"revision"`
+	OrgId      string         `gorm:"primaryKey" json:"org_id"`
+	InstanceId string         `gorm:"primaryKey" json:"instance_id,omitempty"`
+	CreatedAt  time.Time      `json:"-"`
+	UpdatedAt  time.Time      `json:"-"`
+	DeletedAt  gorm.DeletedAt `json:"-"`
+	XTableName string         `gorm:"-" json:"x_table_name"`
 }
 
 func (msg *ProtoStoreMsg) TableName() string {
 	return msg.XTableName
+}
+
+func (msg *ProtoStoreMsg) String() string {
+	if msg == nil {
+		return "{}"
+	}
+
+	if bytes, err := json.Marshal(msg); err != nil {
+		return ""
+	} else {
+		return string(bytes)
+	}
 }
 
 func FromBytes(bytes []byte, message proto.Message) error {

--- a/test/data.go
+++ b/test/data.go
@@ -19,9 +19,9 @@
 package test
 
 import (
+	"encoding/json"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-
 	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/authorizer"
 )
 
@@ -97,10 +97,26 @@ func (a AppUser) AreNonKeyFieldsEmpty() bool {
 	return cmp.Equal(a, AppUser{})
 }
 
+func (a AppUser) String() string {
+	if bytes, err := json.Marshal(a); err != nil {
+		return "{}"
+	} else {
+		return string(bytes)
+	}
+}
+
 func (a App) AreNonKeyFieldsEmpty() bool {
 	a.Id = ""
 	a.TenantId = ""
 	return cmp.Equal(a, App{})
+}
+
+func (a App) String() string {
+	if bytes, err := json.Marshal(a); err != nil {
+		return "{}"
+	} else {
+		return string(bytes)
+	}
 }
 
 type Group struct {
@@ -108,4 +124,12 @@ type Group struct {
 	Name       string
 	Revision   int
 	InstanceId string `gorm:"primaryKey"`
+}
+
+func (g Group) String() string {
+	if bytes, err := json.Marshal(g); err != nil {
+		return "{}"
+	} else {
+		return string(bytes)
+	}
 }


### PR DESCRIPTION
Added `String()` method to `ProtoStoreMsg`, which will print out only ID, org. ID, instance ID, revision, and table name.

---
Before:
```
Unable to locate record [record=&{Id:P4 Msg:[] ParentId: Revision:0 OrgId:Pepsi InstanceId:Americas CreatedAt:0001-01-01 00:00:00 +0000 UTC UpdatedAt:0001-01-01 00:00:00 +0000 UTC DeletedAt:{Time:0001-01-01 00:00:00 +0000 UTC Valid:false} XTableName:processor}, dbName=testprotostoreindbcrud]
	record not found
```

---
After:
```
Unable to locate record [record={"id":"P4","revision":0,"org_id":"Pepsi","instance_id":"Americas","x_table_name":"processor"}, dbName=testprotostoreindbcrud]
	record not found
```

This resolves issue #42 