### PR TITLE
Improve logging at trace level

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -493,14 +493,10 @@ func main() {
 	DevInstanceCtx := instancer.WithInstanceId(ServiceAdminCtx, "Dev")
 	ProdInstanceCtx := instancer.WithInstanceId(ServiceAdminCtx, "Prod")
 
-	// Initializes the Datastore using the metadata authorizer and connection details obtained from the ENV variables, except for DB name.
-	cfg := datastore.ConfigFromEnv("ExampleDataStore_multiInstance" /* dbName */)
-	if err := datastore.DBCreate(cfg); err != nil {
-		log.Fatalf("DB creation failed: %s", err)
-	}
-	ds, err := datastore.FromConfig(datastore.GetCompLogger(), mdAuthorizer, instancer, cfg)
+	// Initializes the Datastore using the metadata authorizer and connection details obtained from the ENV variables.
+	ds, err := datastore.FromEnv(datastore.GetCompLogger(), mdAuthorizer, instancer)
 	if err != nil {
-		log.Fatalf("datastore initialization from config errored: %s", err)
+		log.Fatalf("datastore initialization from env errored: %s", err)
 	}
 
 	// Registers the necessary structs with their corresponding role mappings.
@@ -616,14 +612,10 @@ func main() {
 	CokeOrgCtx := mdAuthorizer.GetAuthContext("Coke", TENANT_ADMIN)
 	PepsiOrgCtx := mdAuthorizer.GetAuthContext("Pepsi", TENANT_ADMIN)
 
-	// Initializes the Datastore using the metadata authorizer and connection details obtained from the ENV variables, except for DB name.
-	cfg := datastore.ConfigFromEnv("ExampleDataStore_multiTenancy" /* dbName */)
-	if err := datastore.DBCreate(cfg); err != nil {
-		log.Fatalf("DB creation failed: %s", err)
-	}
-	ds, err := datastore.FromConfig(datastore.GetCompLogger(), mdAuthorizer, nil /* instancer */, cfg)
+	// Initializes the Datastore using the metadata authorizer and connection details obtained from the ENV variables.
+	ds, err := datastore.FromEnv(datastore.GetCompLogger(), mdAuthorizer, nil)
 	if err != nil {
-		log.Fatalf("datastore initialization from config errored: %s", err)
+		log.Fatalf("datastore initialization from env errored: %s", err)
 	}
 
 	// Registers the necessary structs with their corresponding tenant role mappings.
@@ -1138,10 +1130,7 @@ func main() {
 	// Initialize protostore with proper logger, authorizer and datastore
 	myLogger := datastore.GetCompLogger()
 	mdAuthorizer := authorizer.MetadataBasedAuthorizer{}
-
-	cfg := datastore.ConfigFromEnv("ExampleProtoStore" /* dbName */)
-	_ = datastore.DBCreate(cfg)
-	myDatastore, _ := datastore.FromConfig(myLogger, mdAuthorizer, nil /* instancer */, cfg)
+	myDatastore, _ := datastore.FromEnv(myLogger, mdAuthorizer, nil)
 	ctx := mdAuthorizer.GetAuthContext("Coke", "service_admin")
 	myProtostore := protostore.GetProtoStore(myLogger, myDatastore)
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -286,7 +286,7 @@ Checks if a Postgres DB exists and returns true.
 func GetCompLogger() *logrus.Entry
 ```
 
-## func [GetFieldValue](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/datastore/sql_struct.go#L400>)
+## func [GetFieldValue](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/datastore/sql_struct.go#L399>)
 
 ```go
 func GetFieldValue(record Record, fieldName, columnName string) (string, bool)
@@ -300,7 +300,7 @@ Returns the requested fields value from record, which is a pointer to a struct i
 func GetGormLogger(l *logrus.Entry) logger.Interface
 ```
 
-## func [GetInstanceId](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/datastore/sql_struct.go#L388>)
+## func [GetInstanceId](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/datastore/sql_struct.go#L387>)
 
 ```go
 func GetInstanceId(record Record) (string, bool)
@@ -320,7 +320,7 @@ func GetLogLevel() string
 func GetLogger() *logrus.Logger
 ```
 
-## func [GetOrgId](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/datastore/sql_struct.go#L380>)
+## func [GetOrgId](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/datastore/sql_struct.go#L379>)
 
 ```go
 func GetOrgId(record Record) (string, bool)
@@ -380,13 +380,13 @@ func IsRowLevelSecurityRequired(record Record, tableName string, instancerConfig
 
 Row Level Security to used to partition tables for multi\-tenancy and multi\-instance support.
 
-## func [SetFieldValue](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/datastore/sql_struct.go#L421>)
+## func [SetFieldValue](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/datastore/sql_struct.go#L420>)
 
 ```go
 func SetFieldValue(record Record, fieldName, columnName, value string) bool
 ```
 
-## func [SetInstanceId](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/datastore/sql_struct.go#L392>)
+## func [SetInstanceId](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/datastore/sql_struct.go#L391>)
 
 ```go
 func SetInstanceId(record Record, value string) bool
@@ -397,6 +397,8 @@ func SetInstanceId(record Record, value string) bool
 ```go
 func TypeName(x interface{}) string
 ```
+
+TypeName returns name of the data type of the given variable.
 
 ## type [DBConfig](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/datastore/helper.go#L50-L57>)
 

--- a/pkg/datastore/database.go
+++ b/pkg/datastore/database.go
@@ -513,7 +513,7 @@ func (db *relationalDb) RegisterHelper(_ context.Context, roleMapping map[string
 		roleMapping = make(map[string]dbrole.DbRole)
 	}
 
-	db.logger.Debugf("Registering the struct %q with DAL (backed by Postgres)... Using authorizer %s...", tableName, GetTableName(db.authorizer))
+	db.logger.Debugf("Registering the struct %q with DAL... Using authorizer %s...", tableName, TypeName(db.authorizer))
 
 	tx, err := db.GetDBConn(dbrole.MAIN)
 	if err != nil {

--- a/pkg/datastore/example_multiinstance_test.go
+++ b/pkg/datastore/example_multiinstance_test.go
@@ -38,14 +38,10 @@ func ExampleDataStore_multiInstance() {
 	DevInstanceCtx := instancer.WithInstanceId(ServiceAdminCtx, "Dev")
 	ProdInstanceCtx := instancer.WithInstanceId(ServiceAdminCtx, "Prod")
 
-	// Initializes the Datastore using the metadata authorizer and connection details obtained from the ENV variables, except for DB name.
-	cfg := datastore.ConfigFromEnv("ExampleDataStore_multiInstance" /* dbName */)
-	if err := datastore.DBCreate(cfg); err != nil {
-		log.Fatalf("DB creation failed: %s", err)
-	}
-	ds, err := datastore.FromConfig(datastore.GetCompLogger(), mdAuthorizer, instancer, cfg)
+	// Initializes the Datastore using the metadata authorizer and connection details obtained from the ENV variables.
+	ds, err := datastore.FromEnv(datastore.GetCompLogger(), mdAuthorizer, instancer)
 	if err != nil {
-		log.Fatalf("datastore initialization from config errored: %s", err)
+		log.Fatalf("datastore initialization from env errored: %s", err)
 	}
 
 	// Registers the necessary structs with their corresponding role mappings.

--- a/pkg/datastore/example_multitenancy_test.go
+++ b/pkg/datastore/example_multitenancy_test.go
@@ -35,14 +35,10 @@ func ExampleDataStore_multiTenancy() {
 	CokeOrgCtx := mdAuthorizer.GetAuthContext("Coke", TENANT_ADMIN)
 	PepsiOrgCtx := mdAuthorizer.GetAuthContext("Pepsi", TENANT_ADMIN)
 
-	// Initializes the Datastore using the metadata authorizer and connection details obtained from the ENV variables, except for DB name.
-	cfg := datastore.ConfigFromEnv("ExampleDataStore_multiTenancy" /* dbName */)
-	if err := datastore.DBCreate(cfg); err != nil {
-		log.Fatalf("DB creation failed: %s", err)
-	}
-	ds, err := datastore.FromConfig(datastore.GetCompLogger(), mdAuthorizer, nil /* instancer */, cfg)
+	// Initializes the Datastore using the metadata authorizer and connection details obtained from the ENV variables.
+	ds, err := datastore.FromEnv(datastore.GetCompLogger(), mdAuthorizer, nil)
 	if err != nil {
-		log.Fatalf("datastore initialization from config errored: %s", err)
+		log.Fatalf("datastore initialization from env errored: %s", err)
 	}
 
 	// Registers the necessary structs with their corresponding tenant role mappings.

--- a/pkg/datastore/sql_struct.go
+++ b/pkg/datastore/sql_struct.go
@@ -199,7 +199,6 @@ func getCreatePolicyStmt(tableName string, _ Record, dbUser dbUserSpec) string {
 
 func typeName(x interface{}, prefix string) string {
 	t := reflect.TypeOf(x)
-	TRACE("type for %+v is %s\n", x, t.Kind())
 	for t.Kind() == reflect.Ptr {
 		t = t.Elem()
 		prefix += "*"
@@ -215,6 +214,7 @@ func typeName(x interface{}, prefix string) string {
 	return prefix + t.Name()
 }
 
+// TypeName returns name of the data type of the given variable.
 func TypeName(x interface{}) string {
 	return typeName(x, "")
 }
@@ -245,9 +245,8 @@ func GetTableName(x interface{}) (tableName string) {
 			tableNameMap[typ] = s.Table
 		}
 		tableName = tableNameMap[typ]
-		TRACE("TableName is %s for %s(%+v)\n", tableName, typ, x)
+		TRACE("TableName is %q for %s\n", tableName, typ)
 	}
-	TRACE("TableNameMap is %+v\n", tableNameMap)
 	return tableName
 }
 
@@ -331,7 +330,7 @@ func getCheckAndUpdateRevisionFunc() (functionName, functionBody string) {
 	stmt.WriteString(COLUMN_REVISION)
 	stmt.WriteString(";\n")
 	stmt.WriteString("\t\tEND IF;")
-	return "check_and_update_revision", stmt.String()
+	return "check_and_update_revision", stmt.String() // TODO add version # to function name
 }
 
 func getCreateTriggerFunctionStmt(functionName, functionBody string) string {

--- a/pkg/protostore/example_protostore_test.go
+++ b/pkg/protostore/example_protostore_test.go
@@ -15,10 +15,7 @@ func ExampleProtoStore() {
 	// Initialize protostore with proper logger, authorizer and datastore
 	myLogger := datastore.GetCompLogger()
 	mdAuthorizer := authorizer.MetadataBasedAuthorizer{}
-
-	cfg := datastore.ConfigFromEnv("ExampleProtoStore" /* dbName */)
-	_ = datastore.DBCreate(cfg)
-	myDatastore, _ := datastore.FromConfig(myLogger, mdAuthorizer, nil /* instancer */, cfg)
+	myDatastore, _ := datastore.FromEnv(myLogger, mdAuthorizer, nil)
 	ctx := mdAuthorizer.GetAuthContext("Coke", "service_admin")
 	myProtostore := protostore.GetProtoStore(myLogger, myDatastore)
 


### PR DESCRIPTION
#### Removed or improved trace-level logging statements which were unnecessary or generated hard-to-read logs

---
Removed log statement which generates these logs:
```
TRAC[2023-08-06T18:30:26.741] type for {} is struct                         comp=persistence
TRAC[2023-08-06T06:14:36.205] type for  is ptr                              comp=persistence
TRAC[2023-08-06T06:14:36.197] type for brand:"Samsung"  size:32  speed:2933  type:"DDR4" is ptr  comp=persistence
```

Before:
```
TRAC[2023-08-06T18:43:37.189] Returning db user specs for processor, %!s(bool=true), %!s(bool=true): [{username:writer password:dc9fcb2c policyName:writer_processor_policy commands:[SELECT INSERT UPDATE DELETE] existingRowsCond:instance_id = current_setting('multitenant.instanceId') newRowsCond:instance_id = current_setting('multitenant.instanceId')} {username:reader password:f4f179ac policyName:reader_processor_policy commands:[SELECT] existingRowsCond:instance_id = current_setting('multitenant.instanceId') newRowsCond:false} {username:tenant_writer password:337b0cdb policyName:tenant_writer_processor_policy commands:[SELECT INSERT UPDATE DELETE] existingRowsCond:org_id = current_setting('multitenant.orgId') AND instance_id = current_setting('multitenant.instanceId') newRowsCond:org_id = current_setting('multitenant.orgId') AND instance_id = current_setting('multitenant.instanceId')} {username:tenant_reader password:58c62f67 policyName:tenant_reader_processor_policy commands:[SELECT] existingRowsCond:org_id = current_setting('multitenant.orgId') AND instance_id = current_setting('multitenant.instanceId') newRowsCond:false}]  comp=persistence
```

After:
```
TRAC[2023-08-06T19:15:56.517] Returning DB user specs for table "memories":
	withTenantIdCheck - true
	withInstanceIdCheck -  true
	dbUsers - [{
	"Username": "writer",
	"Password": "*****",
	"PolicyName": "writer_memories_policy",
	"Commands": [
		"SELECT",
		"INSERT",
		"UPDATE",
		"DELETE"
	],
	"ExistingRowsCond": "instance_id = current_setting('multitenant.instanceId')",
	"NewRowsCond": "instance_id = current_setting('multitenant.instanceId')"
} {
	"Username": "reader",
	"Password": "*****",
	"PolicyName": "reader_memories_policy",
	"Commands": [
		"SELECT"
	],
	"ExistingRowsCond": "instance_id = current_setting('multitenant.instanceId')",
	"NewRowsCond": "false"
} {
	"Username": "tenant_writer",
	"Password": "*****",
	"PolicyName": "tenant_writer_memories_policy",
	"Commands": [
		"SELECT",
		"INSERT",
		"UPDATE",
		"DELETE"
	],
	"ExistingRowsCond": "org_id = current_setting('multitenant.orgId') AND instance_id = current_setting('multitenant.instanceId')",
	"NewRowsCond": "org_id = current_setting('multitenant.orgId') AND instance_id = current_setting('multitenant.instanceId')"
} {
	"Username": "tenant_reader",
	"Password": "*****",
	"PolicyName": "tenant_reader_memories_policy",
	"Commands": [
		"SELECT"
	],
	"ExistingRowsCond": "org_id = current_setting('multitenant.orgId') AND instance_id = current_setting('multitenant.instanceId')",
	"NewRowsCond": "false"
}]  comp=persistence
```

Before:
```
TRAC[2023-08-06T18:29:22.761] TableName is memories for *Memory()           comp=persistence
```

After:
```
TRAC[2023-08-06T19:59:31.688] TableName is "memories" for *Memory           comp=persistence
```

---
#### Reversed the changes that led to testable examples using separate DBs, which resulted in Postgres errors (e.g., "remaining connection slots are reserved for non-replication superuser connections")
