### PR TITLE
Use different DBs for example tests

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,7 +9,6 @@ on:
         description: 'Log level'
         required: true
         default: 'trace'
-
 jobs:
   test:
     name: Unit test
@@ -24,6 +23,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
+          cache-dependency-path: go.sum
       - name: Run unit tests
         run: |
           mkdir -p $(go env GOPATH)
@@ -36,7 +36,6 @@ jobs:
           file: test-results/coverage.out
           flags: unit-tests
           name: codecov-unit-test
-
   lint:
     name: Check lint
     runs-on: [ubuntu-latest]
@@ -50,6 +49,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
+          cache-dependency-path: go.sum
       - name: Run lint
         run: |
           mkdir -p $(go env GOPATH)

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,6 @@ on:
         description: 'Log level'
         required: true
         default: 'warning'
-
 jobs:
   test:
     name: Unit test
@@ -36,7 +35,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
-
+          cache-dependency-path: go.sum
       - name: Run unit tests
         run: |
           mkdir -p $(go env GOPATH)
@@ -49,7 +48,6 @@ jobs:
           file: test-results/coverage.out
           flags: unit-tests
           name: codecov-unit-test
-
   lint:
     name: Check lint
     runs-on: [ubuntu-latest]
@@ -63,6 +61,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
+          cache-dependency-path: go.sum
       - name: Run lint
         run: |
           mkdir -p $(go env GOPATH)

--- a/pkg/datastore/database.go
+++ b/pkg/datastore/database.go
@@ -54,6 +54,8 @@ import (
 const (
 	DbConfigOrgId      = "multitenant.orgId"      // Name of Postgres run-time config. parameter that will store current user's org. ID
 	DbConfigInstanceId = "multitenant.instanceId" // Name of Postgres run-time config. parameter that will store current session's instance ID
+
+	MaxIdleConns = 1
 )
 
 /*
@@ -196,6 +198,13 @@ func (db *relationalDb) configureTxWithTenancyScope(tenancyInfo TenancyInfo) (*g
 
 // Reset Resets DB connection pools.
 func (db *relationalDb) Reset() {
+	for _, dbConn := range db.gormDBMap {
+		sqlDB, err := dbConn.DB()
+		if err == nil {
+			sqlDB.Close()
+			sqlDB.SetMaxIdleConns(MaxIdleConns)
+		}
+	}
 	db.gormDBMap = make(map[dbrole.DbRole]*gorm.DB)
 	db.authorizer = authorizer.MetadataBasedAuthorizer{}
 }

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -49,6 +49,7 @@ func TestHasTable(t *testing.T) {
 	assert := assert.New(t)
 
 	ds, _ := SetupDataStore("TestTruncate")
+	defer ds.Reset()
 	_, _, _ = SetupDbTables(ds)
 
 	exists, err := ds.TestHelper().HasTable("non-existent-table")
@@ -64,6 +65,7 @@ func TestTruncate(t *testing.T) {
 	assert := assert.New(t)
 
 	ds, _ := SetupDataStore("TestTruncate")
+	defer ds.Reset()
 	_, _, _ = SetupDbTables(ds)
 
 	queryResults := make([]App, 0)
@@ -85,6 +87,7 @@ func TestTruncate(t *testing.T) {
 func TestTruncateNonExistent(t *testing.T) {
 	assert := assert.New(t)
 	ds, _ := SetupDataStore("TestTruncateNonExistent")
+	defer ds.Reset()
 	err := ds.TestHelper().Truncate("non_existent_table")
 	assert.NoError(err, "Expected no error when trying to truncate a non-existent table")
 }
@@ -93,6 +96,7 @@ func TestFindInEmpty(t *testing.T) {
 	assert := assert.New(t)
 
 	ds, _ := SetupDataStore("TestFindInEmpty")
+	defer ds.Reset()
 	RecreateAllTables(ds)
 
 	{
@@ -189,6 +193,7 @@ func BenchmarkCrud(b *testing.B) {
 
 	var t testing.T
 	ds, _ := SetupDataStore("BenchmarkCrud")
+	defer ds.Reset()
 	myCokeApp, user1, user2 := SetupDbTables(ds)
 	for n := 0; n < b.N; n++ {
 		testCrud(&t, ds, CokeAdminCtx, myCokeApp, user1, user2)
@@ -197,6 +202,7 @@ func BenchmarkCrud(b *testing.B) {
 
 func TestCrud(t *testing.T) {
 	ds, _ := SetupDataStore("TestCrud")
+	defer ds.Reset()
 	myCokeApp, user1, user2 := SetupDbTables(ds)
 	testCrud(t, ds, CokeAdminCtx, myCokeApp, user1, user2)
 }
@@ -204,6 +210,7 @@ func TestCrud(t *testing.T) {
 func TestFindAll(t *testing.T) {
 	assert := assert.New(t)
 	ds, _ := SetupDataStore("TestFindAll")
+	defer ds.Reset()
 	_, user1, user2 := SetupDbTables(ds)
 
 	// FindAll should return all (two) records
@@ -227,6 +234,7 @@ func myID(i int) string {
 func TestFindAllWithPagination(t *testing.T) {
 	assert := assert.New(t)
 	ds, _ := SetupDataStore("TestFindAllWithPagination")
+	defer ds.Reset()
 	RecreateAllTables(ds)
 
 	a1 := &App{}
@@ -269,6 +277,7 @@ func TestFindWithCriteria(t *testing.T) {
 	t.Helper()
 	assert := assert.New(t)
 	ds, _ := SetupDataStore("TestFindWithCriteria")
+	defer ds.Reset()
 	_, user1, user2 := SetupDbTables(ds)
 
 	expected := []*AppUser{user1, user2}
@@ -295,6 +304,7 @@ func TestCrudWithMissingOrgId(t *testing.T) {
 	assert := assert.New(t)
 
 	ds, _ := SetupDataStore("TestCrudWithMissingOrgId")
+	defer ds.Reset()
 	RecreateAllTables(ds)
 	_, apps := make([]AppUser, 0), make([]App, 0)
 
@@ -332,6 +342,7 @@ func TestCrudWithInvalidParams(t *testing.T) {
 	t.Helper()
 	assert := assert.New(t)
 	ds, _ := SetupDataStore("TestCrudWithInvalidParams")
+	defer ds.Reset()
 	RecreateAllTables(ds)
 	ctx := CokeAdminCtx
 
@@ -370,6 +381,7 @@ func TestDALRegistration(t *testing.T) {
 	t.Helper()
 	assert := assert.New(t)
 	ds, _ := SetupDataStore("TestDALRegistration")
+	defer ds.Reset()
 
 	roleMapping := map[string]dbrole.DbRole{SERVICE_AUDITOR: dbrole.READER}
 	// When registering a struct with DAL, you should be able to pass it either by value or by reference
@@ -406,6 +418,7 @@ func TestDeleteWithMultipleCSPRoles(t *testing.T) {
 	const APP_ADMIN = "app_admin"
 	assert := assert.New(t)
 	ds, _ := SetupDataStore("TestDeleteWithMultipleCSPRoles")
+	defer ds.Reset()
 
 	// Create context for custom admin who will have 2 service roles
 	customCtx := ds.GetAuthorizer().GetAuthContext(COKE, APP_ADMIN, SERVICE_ADMIN)
@@ -435,6 +448,7 @@ Tries to perform a query with a service role that has not been authorized to acc
 func TestUnauthorizedAccess(t *testing.T) {
 	assert := assert.New(t)
 	ds, _ := SetupDataStore("TestUnauthorizedAccess")
+	defer ds.Reset()
 
 	myCokeApp, _, _ := SetupDbTables(ds)
 	ctx := ds.GetAuthorizer().GetAuthContext(COKE, "unauthorized service role")
@@ -450,6 +464,7 @@ func TestCrudWithMismatchingOrgId(t *testing.T) {
 	t.Helper()
 	assert := assert.New(t)
 	ds, _ := SetupDataStore("TestCrudWithMismatchingOrgId")
+	defer ds.Reset()
 	myCokeApp, _, _ := SetupDbTables(ds)
 	tenantStr := "tenant=Pepsi"
 	orgIdStr := "orgIdCol=Coke"
@@ -597,6 +612,7 @@ Tests revision blocking updates that are outdated.
 func TestRevision(t *testing.T) {
 	assert := assert.New(t)
 	ds, _ := SetupDataStore("TestRevision")
+	defer ds.Reset()
 
 	if err := ds.TestHelper().DropTables(&Group{}); err != nil {
 		assert.FailNow("Failed to drop DB tables for the following reason:\n" + err.Error())
@@ -701,6 +717,7 @@ func TestRevision(t *testing.T) {
 func TestTransactions(t *testing.T) {
 	assert := assert.New(t)
 	ds, ps := SetupDataStore("TestTransactions")
+	defer ds.Reset()
 	_, _, _ = SetupDbTables(ds)
 	roleMapping := map[string]dbrole.DbRole{
 		TENANT_AUDITOR:  dbrole.TENANT_READER,

--- a/pkg/datastore/datastore_with_txcontext_test.go
+++ b/pkg/datastore/datastore_with_txcontext_test.go
@@ -127,6 +127,7 @@ func BenchmarkTxCrud(b *testing.B) {
 
 	var t testing.T
 	ds, _ := SetupDataStore("BenchmarkCrud")
+	defer ds.Reset()
 	myCokeApp, user1, user2 := SetupDbTables(ds)
 	for n := 0; n < b.N; n++ {
 		testCrud(&t, ds, CokeAdminCtx, myCokeApp, user1, user2)
@@ -135,6 +136,7 @@ func BenchmarkTxCrud(b *testing.B) {
 
 func TestTxCrud(t *testing.T) {
 	ds, _ := SetupDataStore("TestTxCrud")
+	defer ds.Reset()
 	myCokeApp, user1, user2 := SetupDbTables(ds)
 	testTxCrud(t, ds, CokeAdminCtx, myCokeApp, user1, user2)
 }

--- a/pkg/datastore/example_multiinstance_test.go
+++ b/pkg/datastore/example_multiinstance_test.go
@@ -39,7 +39,7 @@ func ExampleDataStore_multiInstance() {
 	ProdInstanceCtx := instancer.WithInstanceId(ServiceAdminCtx, "Prod")
 
 	// Initializes the Datastore using the metadata authorizer and connection details obtained from the ENV variables.
-	ds, err := datastore.FromEnv(datastore.GetCompLogger(), mdAuthorizer, instancer)
+	ds, err := datastore.FromEnvWithDB(datastore.GetCompLogger(), mdAuthorizer, instancer, "ExampleDataStore_multiInstance")
 	if err != nil {
 		log.Fatalf("datastore initialization from env errored: %s", err)
 	}

--- a/pkg/datastore/example_multitenancy_test.go
+++ b/pkg/datastore/example_multitenancy_test.go
@@ -36,7 +36,7 @@ func ExampleDataStore_multiTenancy() {
 	PepsiOrgCtx := mdAuthorizer.GetAuthContext("Pepsi", TENANT_ADMIN)
 
 	// Initializes the Datastore using the metadata authorizer and connection details obtained from the ENV variables.
-	ds, err := datastore.FromEnv(datastore.GetCompLogger(), mdAuthorizer, nil)
+	ds, err := datastore.FromEnvWithDB(datastore.GetCompLogger(), mdAuthorizer, nil, "ExampleDataStore_multiTenancy")
 	if err != nil {
 		log.Fatalf("datastore initialization from env errored: %s", err)
 	}

--- a/pkg/protostore/example_protostore_test.go
+++ b/pkg/protostore/example_protostore_test.go
@@ -15,7 +15,7 @@ func ExampleProtoStore() {
 	// Initialize protostore with proper logger, authorizer and datastore
 	myLogger := datastore.GetCompLogger()
 	mdAuthorizer := authorizer.MetadataBasedAuthorizer{}
-	myDatastore, _ := datastore.FromEnv(myLogger, mdAuthorizer, nil)
+	myDatastore, _ := datastore.FromEnvWithDB(myLogger, mdAuthorizer, nil, "ExampleProtoStore")
 	ctx := mdAuthorizer.GetAuthContext("Coke", "service_admin")
 	myProtostore := protostore.GetProtoStore(myLogger, myDatastore)
 


### PR DESCRIPTION
- Example tests are failing if they are using same DB sometimes, instead using different DBs using FromEnvWithDB() method

Fixes #53