### PR TITLE
Add instancer based roles and users

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -163,6 +163,11 @@ linters-settings:
 
 issues:
   exclude-rules:
+    - path: pkg/authorizer/metadata_authorizer.go
+      linters:
+        - cyclop
+        - gocognit
+        - nestif
     - path: _test\.go
       linters:
         - cyclop

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -21,12 +21,12 @@ import "github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/authorizer"
 - [type MetadataBasedAuthorizer](<#MetadataBasedAuthorizer>)
   - [func \(s MetadataBasedAuthorizer\) Configure\(\_ string, \_ map\[string\]dbrole.DbRole\)](<#MetadataBasedAuthorizer.Configure>)
   - [func \(s MetadataBasedAuthorizer\) GetAuthContext\(orgId string, roles ...string\) context.Context](<#MetadataBasedAuthorizer.GetAuthContext>)
-  - [func \(s MetadataBasedAuthorizer\) GetDefaultOrgAdminContext\(\) context.Context](<#MetadataBasedAuthorizer.GetDefaultOrgAdminContext>)
-  - [func \(s MetadataBasedAuthorizer\) GetMatchingDbRole\(ctx context.Context, \_ ...string\) \(dbrole.DbRole, error\)](<#MetadataBasedAuthorizer.GetMatchingDbRole>)
-  - [func \(s MetadataBasedAuthorizer\) GetOrgFromContext\(ctx context.Context\) \(string, error\)](<#MetadataBasedAuthorizer.GetOrgFromContext>)
+  - [func \(s \*MetadataBasedAuthorizer\) GetDefaultOrgAdminContext\(\) context.Context](<#MetadataBasedAuthorizer.GetDefaultOrgAdminContext>)
+  - [func \(s \*MetadataBasedAuthorizer\) GetMatchingDbRole\(ctx context.Context, tableNames ...string\) \(dbrole.DbRole, error\)](<#MetadataBasedAuthorizer.GetMatchingDbRole>)
+  - [func \(s \*MetadataBasedAuthorizer\) GetOrgFromContext\(ctx context.Context\) \(string, error\)](<#MetadataBasedAuthorizer.GetOrgFromContext>)
 - [type SimpleInstancer](<#SimpleInstancer>)
-  - [func \(s SimpleInstancer\) GetInstanceId\(ctx context.Context\) \(string, error\)](<#SimpleInstancer.GetInstanceId>)
-  - [func \(s SimpleInstancer\) WithInstanceId\(ctx context.Context, instanceId string\) context.Context](<#SimpleInstancer.WithInstanceId>)
+  - [func \(s \*SimpleInstancer\) GetInstanceId\(ctx context.Context\) \(string, error\)](<#SimpleInstancer.GetInstanceId>)
+  - [func \(s \*SimpleInstancer\) WithInstanceId\(ctx context.Context, instanceId string\) context.Context](<#SimpleInstancer.WithInstanceId>)
 - [type SimpleTransactionFetcher](<#SimpleTransactionFetcher>)
   - [func \(s SimpleTransactionFetcher\) GetTransactionCtx\(ctx context.Context\) \*gorm.DB](<#SimpleTransactionFetcher.GetTransactionCtx>)
   - [func \(s SimpleTransactionFetcher\) IsTransactionCtx\(ctx context.Context\) bool](<#SimpleTransactionFetcher.IsTransactionCtx>)
@@ -133,28 +133,28 @@ func (s MetadataBasedAuthorizer) GetAuthContext(orgId string, roles ...string) c
 
 
 <a name="MetadataBasedAuthorizer.GetDefaultOrgAdminContext"></a>
-### func \(MetadataBasedAuthorizer\) [GetDefaultOrgAdminContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L89>)
+### func \(\*MetadataBasedAuthorizer\) [GetDefaultOrgAdminContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L89>)
 
 ```go
-func (s MetadataBasedAuthorizer) GetDefaultOrgAdminContext() context.Context
+func (s *MetadataBasedAuthorizer) GetDefaultOrgAdminContext() context.Context
 ```
 
 
 
 <a name="MetadataBasedAuthorizer.GetMatchingDbRole"></a>
-### func \(MetadataBasedAuthorizer\) [GetMatchingDbRole](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L58>)
+### func \(\*MetadataBasedAuthorizer\) [GetMatchingDbRole](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L58>)
 
 ```go
-func (s MetadataBasedAuthorizer) GetMatchingDbRole(ctx context.Context, _ ...string) (dbrole.DbRole, error)
+func (s *MetadataBasedAuthorizer) GetMatchingDbRole(ctx context.Context, tableNames ...string) (dbrole.DbRole, error)
 ```
 
 
 
 <a name="MetadataBasedAuthorizer.GetOrgFromContext"></a>
-### func \(MetadataBasedAuthorizer\) [GetOrgFromContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L44>)
+### func \(\*MetadataBasedAuthorizer\) [GetOrgFromContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L44>)
 
 ```go
-func (s MetadataBasedAuthorizer) GetOrgFromContext(ctx context.Context) (string, error)
+func (s *MetadataBasedAuthorizer) GetOrgFromContext(ctx context.Context) (string, error)
 ```
 
 
@@ -169,19 +169,19 @@ type SimpleInstancer struct{}
 ```
 
 <a name="SimpleInstancer.GetInstanceId"></a>
-### func \(SimpleInstancer\) [GetInstanceId](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/instancer.go#L23>)
+### func \(\*SimpleInstancer\) [GetInstanceId](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/instancer.go#L23>)
 
 ```go
-func (s SimpleInstancer) GetInstanceId(ctx context.Context) (string, error)
+func (s *SimpleInstancer) GetInstanceId(ctx context.Context) (string, error)
 ```
 
 
 
 <a name="SimpleInstancer.WithInstanceId"></a>
-### func \(SimpleInstancer\) [WithInstanceId](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/instancer.go#L30>)
+### func \(\*SimpleInstancer\) [WithInstanceId](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/instancer.go#L30>)
 
 ```go
-func (s SimpleInstancer) WithInstanceId(ctx context.Context, instanceId string) context.Context
+func (s *SimpleInstancer) WithInstanceId(ctx context.Context, instanceId string) context.Context
 ```
 
 
@@ -659,8 +659,8 @@ func main() {
 
 	SERVICE_ADMIN := "service_admin"
 	SERVICE_AUDITOR := "service_auditor"
-	mdAuthorizer := authorizer.MetadataBasedAuthorizer{}
-	instancer := authorizer.SimpleInstancer{}
+	mdAuthorizer := &authorizer.MetadataBasedAuthorizer{}
+	instancer := &authorizer.SimpleInstancer{}
 
 	ServiceAdminCtx := mdAuthorizer.GetAuthContext("", SERVICE_ADMIN)
 	DevInstanceCtx := instancer.WithInstanceId(ServiceAdminCtx, "Dev")
@@ -782,7 +782,7 @@ func main() {
 
 	TENANT_ADMIN := "tenant_admin"
 	TENANT_AUDITOR := "tenant_auditor"
-	mdAuthorizer := authorizer.MetadataBasedAuthorizer{}
+	mdAuthorizer := &authorizer.MetadataBasedAuthorizer{}
 	CokeOrgCtx := mdAuthorizer.GetAuthContext("Coke", TENANT_ADMIN)
 	PepsiOrgCtx := mdAuthorizer.GetAuthContext("Pepsi", TENANT_ADMIN)
 
@@ -1001,18 +1001,22 @@ import "github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/dbrole"
 DAL uses 4 database roles/users to perform all operations,
 
 - \`TENANT\_READER\` \- has read access to its tenant's data
-
 - \`READER\` \- has read access to all tenants' data
-
 - \`TENANT\_WRITER\` \- has read & write access to its tenant's data
-
 - \`WRITER\` \- has read & write access to all tenants' data
-  
-  DAL allows to map a user's service role to the DB role that will be used for that user. If a user has multiple service roles which map to several DB roles, the DB role with the most extensive privileges will be used \(see \`DbRoles\(\)\` for reference to ordered list of DbRoles.
+
+Corresponding \*INSTANCE\_\* roles access is determined by the Instancer's configuration, allowing it to access records exclusively with a specific instance.
+
+DAL allows to map a user's service role to the DB role that will be used for that user. If a user has multiple service roles which map to several DB roles, the DB role with the most extensive privileges will be used \(see \`DbRoles\(\)\` for reference to ordered list of DbRoles.
 
 ## Index
 
 - [type DbRole](<#DbRole>)
+  - [func Max\(dbRoles \[\]DbRole\) DbRole](<#Max>)
+  - [func Min\(dbRoles \[\]DbRole\) DbRole](<#Min>)
+  - [func \(dbRole DbRole\) GetRoleWithInstancer\(\) DbRole](<#DbRole.GetRoleWithInstancer>)
+  - [func \(dbRole DbRole\) GetRoleWithTenancy\(\) DbRole](<#DbRole.GetRoleWithTenancy>)
+  - [func \(dbRole DbRole\) IsDbRoleInstanceScoped\(\) bool](<#DbRole.IsDbRoleInstanceScoped>)
   - [func \(dbRole DbRole\) IsDbRoleTenantScoped\(\) bool](<#DbRole.IsDbRoleTenantScoped>)
 - [type DbRoleSlice](<#DbRoleSlice>)
   - [func DbRoles\(\) DbRoleSlice](<#DbRoles>)
@@ -1022,7 +1026,7 @@ DAL uses 4 database roles/users to perform all operations,
 
 
 <a name="DbRole"></a>
-## type [DbRole](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L33>)
+## type [DbRole](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L38>)
 
 DbRole Database roles/users.
 
@@ -1035,17 +1039,66 @@ type DbRole string
 ```go
 const (
     // NO_ROLE DB Roles.
-    NO_ROLE       DbRole = ""
-    TENANT_READER DbRole = "tenant_reader"
-    READER        DbRole = "reader"
-    TENANT_WRITER DbRole = "tenant_writer"
-    WRITER        DbRole = "writer"
-    MAIN          DbRole = "main"
+    NO_ROLE                DbRole = ""
+    TENANT_INSTANCE_READER DbRole = "tenant_instance_reader"
+    TENANT_READER          DbRole = "tenant_reader"
+    INSTANCE_READER        DbRole = "instance_reader"
+    READER                 DbRole = "reader"
+    TENANT_INSTANCE_WRITER DbRole = "tenant_instance_writer"
+    TENANT_WRITER          DbRole = "tenant_writer"
+    INSTANCE_WRITER        DbRole = "instance_writer"
+    WRITER                 DbRole = "writer"
+    MAIN                   DbRole = "main"
 )
 ```
 
+<a name="Max"></a>
+### func [Max](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L133>)
+
+```go
+func Max(dbRoles []DbRole) DbRole
+```
+
+
+
+<a name="Min"></a>
+### func [Min](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L138>)
+
+```go
+func Min(dbRoles []DbRole) DbRole
+```
+
+
+
+<a name="DbRole.GetRoleWithInstancer"></a>
+### func \(DbRole\) [GetRoleWithInstancer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L82>)
+
+```go
+func (dbRole DbRole) GetRoleWithInstancer() DbRole
+```
+
+Map roles to instancer based when Instancer is set.
+
+<a name="DbRole.GetRoleWithTenancy"></a>
+### func \(DbRole\) [GetRoleWithTenancy](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L98>)
+
+```go
+func (dbRole DbRole) GetRoleWithTenancy() DbRole
+```
+
+Map roles to tenancy based roles as tenant column is configured.
+
+<a name="DbRole.IsDbRoleInstanceScoped"></a>
+### func \(DbRole\) [IsDbRoleInstanceScoped](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L77>)
+
+```go
+func (dbRole DbRole) IsDbRoleInstanceScoped() bool
+```
+
+
+
 <a name="DbRole.IsDbRoleTenantScoped"></a>
-### func \(DbRole\) [IsDbRoleTenantScoped](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L66>)
+### func \(DbRole\) [IsDbRoleTenantScoped](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L73>)
 
 ```go
 func (dbRole DbRole) IsDbRoleTenantScoped() bool
@@ -1054,7 +1107,7 @@ func (dbRole DbRole) IsDbRoleTenantScoped() bool
 
 
 <a name="DbRoleSlice"></a>
-## type [DbRoleSlice](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L61>)
+## type [DbRoleSlice](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L123>)
 
 
 
@@ -1063,16 +1116,16 @@ type DbRoleSlice []DbRole // Needed for sorting records
 ```
 
 <a name="DbRoles"></a>
-### func [DbRoles](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L50>)
+### func [DbRoles](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L58>)
 
 ```go
 func DbRoles() DbRoleSlice
 ```
 
-Returns \*Ordered\* slice of DbRoles. A reader role is always considered to have fewer permissions than a writer role. and a tenant\-specific reader/writer role is always considered to have fewer permissions, than a non\-tenant specific reader/writer role, respectively. NO\_ROLE \< TENANT\_READER \< READER \< TENANT\_WRITER \< WRITER.
+Returns \*Ordered\* slice of DbRoles. A reader role is always considered to have fewer permissions than a writer role. and a tenant\-specific reader/writer role is always considered to have fewer permissions, than a non\-tenant specific reader/writer role, respectively.
 
 <a name="DbRoleSlice.Len"></a>
-### func \(DbRoleSlice\) [Len](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L62>)
+### func \(DbRoleSlice\) [Len](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L131>)
 
 ```go
 func (a DbRoleSlice) Len() int
@@ -1081,7 +1134,7 @@ func (a DbRoleSlice) Len() int
 
 
 <a name="DbRoleSlice.Less"></a>
-### func \(DbRoleSlice\) [Less](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L83>)
+### func \(DbRoleSlice\) [Less](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L127>)
 
 ```go
 func (a DbRoleSlice) Less(i, j int) bool
@@ -1090,7 +1143,7 @@ func (a DbRoleSlice) Less(i, j int) bool
 Returns true if the first role has fewer permissions than the second role, and true if the two roles are the same or the second role has more permissions.
 
 <a name="DbRoleSlice.Swap"></a>
-### func \(DbRoleSlice\) [Swap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L87>)
+### func \(DbRoleSlice\) [Swap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L129>)
 
 ```go
 func (a DbRoleSlice) Swap(i, j int)
@@ -1418,7 +1471,7 @@ import (
 func main() {
 	// Initialize protostore with proper logger, authorizer and datastore
 	myLogger := datastore.GetCompLogger()
-	mdAuthorizer := authorizer.MetadataBasedAuthorizer{}
+	mdAuthorizer := &authorizer.MetadataBasedAuthorizer{}
 	myDatastore, _ := datastore.FromEnvWithDB(myLogger, mdAuthorizer, nil, "ExampleProtoStore")
 	defer myDatastore.Reset()
 	ctx := mdAuthorizer.GetAuthContext("Coke", "service_admin")

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -19,8 +19,8 @@ import "github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/authorizer"
 - [type ContextKey](<#ContextKey>)
 - [type Instancer](<#Instancer>)
 - [type MetadataBasedAuthorizer](<#MetadataBasedAuthorizer>)
-  - [func \(s MetadataBasedAuthorizer\) Configure\(\_ string, \_ map\[string\]dbrole.DbRole\)](<#MetadataBasedAuthorizer.Configure>)
-  - [func \(s MetadataBasedAuthorizer\) GetAuthContext\(orgId string, roles ...string\) context.Context](<#MetadataBasedAuthorizer.GetAuthContext>)
+  - [func \(s \*MetadataBasedAuthorizer\) Configure\(tableName string, roleMapping map\[string\]dbrole.DbRole\)](<#MetadataBasedAuthorizer.Configure>)
+  - [func \(s \*MetadataBasedAuthorizer\) GetAuthContext\(orgId string, roles ...string\) context.Context](<#MetadataBasedAuthorizer.GetAuthContext>)
   - [func \(s \*MetadataBasedAuthorizer\) GetDefaultOrgAdminContext\(\) context.Context](<#MetadataBasedAuthorizer.GetDefaultOrgAdminContext>)
   - [func \(s \*MetadataBasedAuthorizer\) GetMatchingDbRole\(ctx context.Context, tableNames ...string\) \(dbrole.DbRole, error\)](<#MetadataBasedAuthorizer.GetMatchingDbRole>)
   - [func \(s \*MetadataBasedAuthorizer\) GetOrgFromContext\(ctx context.Context\) \(string, error\)](<#MetadataBasedAuthorizer.GetOrgFromContext>)
@@ -106,34 +106,36 @@ type Instancer interface {
 ```
 
 <a name="MetadataBasedAuthorizer"></a>
-## type [MetadataBasedAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L42>)
+## type [MetadataBasedAuthorizer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L42-L44>)
 
 
 
 ```go
-type MetadataBasedAuthorizer struct{}
+type MetadataBasedAuthorizer struct {
+    // contains filtered or unexported fields
+}
 ```
 
 <a name="MetadataBasedAuthorizer.Configure"></a>
-### func \(MetadataBasedAuthorizer\) [Configure](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L80>)
+### func \(\*MetadataBasedAuthorizer\) [Configure](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L107>)
 
 ```go
-func (s MetadataBasedAuthorizer) Configure(_ string, _ map[string]dbrole.DbRole)
+func (s *MetadataBasedAuthorizer) Configure(tableName string, roleMapping map[string]dbrole.DbRole)
 ```
 
 
 
 <a name="MetadataBasedAuthorizer.GetAuthContext"></a>
-### func \(MetadataBasedAuthorizer\) [GetAuthContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L85>)
+### func \(\*MetadataBasedAuthorizer\) [GetAuthContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L116>)
 
 ```go
-func (s MetadataBasedAuthorizer) GetAuthContext(orgId string, roles ...string) context.Context
+func (s *MetadataBasedAuthorizer) GetAuthContext(orgId string, roles ...string) context.Context
 ```
 
 
 
 <a name="MetadataBasedAuthorizer.GetDefaultOrgAdminContext"></a>
-### func \(\*MetadataBasedAuthorizer\) [GetDefaultOrgAdminContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L89>)
+### func \(\*MetadataBasedAuthorizer\) [GetDefaultOrgAdminContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L124>)
 
 ```go
 func (s *MetadataBasedAuthorizer) GetDefaultOrgAdminContext() context.Context
@@ -142,7 +144,7 @@ func (s *MetadataBasedAuthorizer) GetDefaultOrgAdminContext() context.Context
 
 
 <a name="MetadataBasedAuthorizer.GetMatchingDbRole"></a>
-### func \(\*MetadataBasedAuthorizer\) [GetMatchingDbRole](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L58>)
+### func \(\*MetadataBasedAuthorizer\) [GetMatchingDbRole](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L60>)
 
 ```go
 func (s *MetadataBasedAuthorizer) GetMatchingDbRole(ctx context.Context, tableNames ...string) (dbrole.DbRole, error)
@@ -151,7 +153,7 @@ func (s *MetadataBasedAuthorizer) GetMatchingDbRole(ctx context.Context, tableNa
 
 
 <a name="MetadataBasedAuthorizer.GetOrgFromContext"></a>
-### func \(\*MetadataBasedAuthorizer\) [GetOrgFromContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L44>)
+### func \(\*MetadataBasedAuthorizer\) [GetOrgFromContext](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/authorizer/metadata_authorizer.go#L46>)
 
 ```go
 func (s *MetadataBasedAuthorizer) GetOrgFromContext(ctx context.Context) (string, error)
@@ -675,8 +677,8 @@ func main() {
 
 	// Registers the necessary structs with their corresponding role mappings.
 	roleMapping := map[string]dbrole.DbRole{
-		SERVICE_AUDITOR: dbrole.READER,
-		SERVICE_ADMIN:   dbrole.WRITER,
+		SERVICE_AUDITOR: dbrole.INSTANCE_READER,
+		SERVICE_ADMIN:   dbrole.INSTANCE_WRITER,
 	}
 	if err = ds.Register(context.TODO(), roleMapping, &Person{}); err != nil {
 		log.Fatalf("Failed to create DB tables: %+v", err)
@@ -998,14 +1000,12 @@ type TestHelper interface {
 import "github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/dbrole"
 ```
 
-DAL uses 4 database roles/users to perform all operations,
-
-- \`TENANT\_READER\` \- has read access to its tenant's data
-- \`READER\` \- has read access to all tenants' data
-- \`TENANT\_WRITER\` \- has read & write access to its tenant's data
-- \`WRITER\` \- has read & write access to all tenants' data
-
 Corresponding \*INSTANCE\_\* roles access is determined by the Instancer's configuration, allowing it to access records exclusively with a specific instance.
+
+- \`TENANT\_INSTANCE\_READER\` \- has read access to its tenant instance's data
+- \`INSTANCE\_READER\` \- has read access to specific instance data
+- \`TENANT\_INSTANCE\_WRITER\` \- has read & write access to its tenant instance's data
+- \`INSTANCE\_WRITER\` \- has read & write access to specific instance data
 
 DAL allows to map a user's service role to the DB role that will be used for that user. If a user has multiple service roles which map to several DB roles, the DB role with the most extensive privileges will be used \(see \`DbRoles\(\)\` for reference to ordered list of DbRoles.
 
@@ -1015,7 +1015,6 @@ DAL allows to map a user's service role to the DB role that will be used for tha
   - [func Max\(dbRoles \[\]DbRole\) DbRole](<#Max>)
   - [func Min\(dbRoles \[\]DbRole\) DbRole](<#Min>)
   - [func \(dbRole DbRole\) GetRoleWithInstancer\(\) DbRole](<#DbRole.GetRoleWithInstancer>)
-  - [func \(dbRole DbRole\) GetRoleWithTenancy\(\) DbRole](<#DbRole.GetRoleWithTenancy>)
   - [func \(dbRole DbRole\) IsDbRoleInstanceScoped\(\) bool](<#DbRole.IsDbRoleInstanceScoped>)
   - [func \(dbRole DbRole\) IsDbRoleTenantScoped\(\) bool](<#DbRole.IsDbRoleTenantScoped>)
 - [type DbRoleSlice](<#DbRoleSlice>)
@@ -1026,7 +1025,7 @@ DAL allows to map a user's service role to the DB role that will be used for tha
 
 
 <a name="DbRole"></a>
-## type [DbRole](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L38>)
+## type [DbRole](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L42>)
 
 DbRole Database roles/users.
 
@@ -1053,7 +1052,7 @@ const (
 ```
 
 <a name="Max"></a>
-### func [Max](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L133>)
+### func [Max](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L123>)
 
 ```go
 func Max(dbRoles []DbRole) DbRole
@@ -1062,7 +1061,7 @@ func Max(dbRoles []DbRole) DbRole
 
 
 <a name="Min"></a>
-### func [Min](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L138>)
+### func [Min](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L128>)
 
 ```go
 func Min(dbRoles []DbRole) DbRole
@@ -1071,25 +1070,16 @@ func Min(dbRoles []DbRole) DbRole
 
 
 <a name="DbRole.GetRoleWithInstancer"></a>
-### func \(DbRole\) [GetRoleWithInstancer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L82>)
+### func \(DbRole\) [GetRoleWithInstancer](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L88>)
 
 ```go
 func (dbRole DbRole) GetRoleWithInstancer() DbRole
 ```
 
-Map roles to instancer based when Instancer is set.
-
-<a name="DbRole.GetRoleWithTenancy"></a>
-### func \(DbRole\) [GetRoleWithTenancy](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L98>)
-
-```go
-func (dbRole DbRole) GetRoleWithTenancy() DbRole
-```
-
-Map roles to tenancy based roles as tenant column is configured.
+Map roles to instancer based when Instancer is set. Useful for backward compatibility when role Mapping do not reference \*INSTANCE\* roles, but an Instancer is configured to limit the access to an instance.
 
 <a name="DbRole.IsDbRoleInstanceScoped"></a>
-### func \(DbRole\) [IsDbRoleInstanceScoped](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L77>)
+### func \(DbRole\) [IsDbRoleInstanceScoped](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L81>)
 
 ```go
 func (dbRole DbRole) IsDbRoleInstanceScoped() bool
@@ -1098,7 +1088,7 @@ func (dbRole DbRole) IsDbRoleInstanceScoped() bool
 
 
 <a name="DbRole.IsDbRoleTenantScoped"></a>
-### func \(DbRole\) [IsDbRoleTenantScoped](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L73>)
+### func \(DbRole\) [IsDbRoleTenantScoped](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L77>)
 
 ```go
 func (dbRole DbRole) IsDbRoleTenantScoped() bool
@@ -1107,7 +1097,7 @@ func (dbRole DbRole) IsDbRoleTenantScoped() bool
 
 
 <a name="DbRoleSlice"></a>
-## type [DbRoleSlice](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L123>)
+## type [DbRoleSlice](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L113>)
 
 
 
@@ -1116,7 +1106,7 @@ type DbRoleSlice []DbRole // Needed for sorting records
 ```
 
 <a name="DbRoles"></a>
-### func [DbRoles](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L58>)
+### func [DbRoles](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L62>)
 
 ```go
 func DbRoles() DbRoleSlice
@@ -1125,7 +1115,7 @@ func DbRoles() DbRoleSlice
 Returns \*Ordered\* slice of DbRoles. A reader role is always considered to have fewer permissions than a writer role. and a tenant\-specific reader/writer role is always considered to have fewer permissions, than a non\-tenant specific reader/writer role, respectively.
 
 <a name="DbRoleSlice.Len"></a>
-### func \(DbRoleSlice\) [Len](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L131>)
+### func \(DbRoleSlice\) [Len](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L121>)
 
 ```go
 func (a DbRoleSlice) Len() int
@@ -1134,7 +1124,7 @@ func (a DbRoleSlice) Len() int
 
 
 <a name="DbRoleSlice.Less"></a>
-### func \(DbRoleSlice\) [Less](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L127>)
+### func \(DbRoleSlice\) [Less](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L117>)
 
 ```go
 func (a DbRoleSlice) Less(i, j int) bool
@@ -1143,7 +1133,7 @@ func (a DbRoleSlice) Less(i, j int) bool
 Returns true if the first role has fewer permissions than the second role, and true if the two roles are the same or the second role has more permissions.
 
 <a name="DbRoleSlice.Swap"></a>
-### func \(DbRoleSlice\) [Swap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L129>)
+### func \(DbRoleSlice\) [Swap](<https://github.com/vmware-labs/multi-tenant-persistence-for-saas/blob/main/pkg/dbrole/dbrole.go#L119>)
 
 ```go
 func (a DbRoleSlice) Swap(i, j int)

--- a/pkg/authorizer/metadata_authorizer.go
+++ b/pkg/authorizer/metadata_authorizer.go
@@ -39,7 +39,9 @@ const (
 	METADATA_ROLE_AUDITOR         = "auditor" // can be tenant_auditor, *_auditor
 )
 
-type MetadataBasedAuthorizer struct{}
+type MetadataBasedAuthorizer struct {
+	roleMapping map[string]map[string]dbrole.DbRole // Maps DB table to its service roles and matching DB roles
+}
 
 func (s *MetadataBasedAuthorizer) GetOrgFromContext(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
@@ -61,15 +63,40 @@ func (s *MetadataBasedAuthorizer) GetMatchingDbRole(ctx context.Context, tableNa
 		return dbrole.NO_ROLE, ErrFetchingMetadata
 	}
 
-	role := md[METADATA_KEY_ROLE]
-	if len(role) > 0 {
-		switch role[len(role)-1] {
+	// Returns the min role across tables and max within a table for given serviceRoles
+	serviceRoles := md[METADATA_KEY_ROLE]
+	if len(serviceRoles) > 0 {
+		// Use roleMapping if configured
+		if s.roleMapping != nil {
+			allTableRoles := make([]dbrole.DbRole, 0)
+			for _, tableName := range tableNames {
+				dbRoles := make([]dbrole.DbRole, 0)
+				for _, serviceRole := range serviceRoles {
+					if rMapping, ok := s.roleMapping[tableName]; ok {
+						if dbRole, ok := rMapping[serviceRole]; ok {
+							dbRoles = append(dbRoles, dbRole)
+						}
+					}
+				}
+				if len(dbRoles) > 0 {
+					allTableRoles = append(allTableRoles, dbrole.Max(dbRoles))
+				} else {
+					break
+				}
+			}
+			if len(allTableRoles) > 0 {
+				return dbrole.Min(allTableRoles), nil
+			}
+		}
+
+		serviceRole := serviceRoles[len(serviceRoles)-1]
+		switch serviceRole {
 		case METADATA_ROLE_SERVICE_ADMIN:
 			return dbrole.WRITER, nil
 		case METADATA_ROLE_SERVICE_AUDITOR:
 			return dbrole.READER, nil
 		default:
-			if strings.HasSuffix(role[len(role)-1], METADATA_ROLE_ADMIN) {
+			if strings.HasSuffix(serviceRole, METADATA_ROLE_ADMIN) {
 				return dbrole.TENANT_WRITER, nil
 			}
 		}
@@ -77,13 +104,21 @@ func (s *MetadataBasedAuthorizer) GetMatchingDbRole(ctx context.Context, tableNa
 	return dbrole.TENANT_READER, nil
 }
 
-func (s MetadataBasedAuthorizer) Configure(_ string, _ map[string]dbrole.DbRole) {
-	// TODO - Set "service role" to DB role mapping here"
-	// Currently MetadataBasedAuthorizer, doesn't support service to DB role mapping
+func (s *MetadataBasedAuthorizer) Configure(tableName string, roleMapping map[string]dbrole.DbRole) {
+	if s.roleMapping == nil {
+		// TRACE("RoleMapping: setting to NEWMAP")
+		s.roleMapping = make(map[string]map[string]dbrole.DbRole)
+	}
+	s.roleMapping[tableName] = roleMapping
+	// TRACE("RoleMapping: configured for table %s: %+v", tableName, s.roleMapping)
 }
 
-func (s MetadataBasedAuthorizer) GetAuthContext(orgId string, roles ...string) context.Context {
-	return metadata.NewIncomingContext(context.Background(), metadata.Pairs(METADATA_KEY_ORGID, orgId, METADATA_KEY_ROLE, roles[0]))
+func (s *MetadataBasedAuthorizer) GetAuthContext(orgId string, roles ...string) context.Context {
+	md := metadata.Pairs(METADATA_KEY_ORGID, orgId)
+	for _, role := range roles {
+		md.Append(METADATA_KEY_ROLE, role)
+	}
+	return metadata.NewIncomingContext(context.Background(), md)
 }
 
 func (s *MetadataBasedAuthorizer) GetDefaultOrgAdminContext() context.Context {

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -729,6 +729,6 @@ func TestTransactions(t *testing.T) {
 	assert.NoError(err)
 
 	testSingleTableTransactions(t, ds, ps)
-	// testMultiTableTransactions(t, ds, ps)
-	// testMultiProtoTransactions(t, ds, ps)
+	testMultiTableTransactions(t, ds, ps)
+	testMultiProtoTransactions(t, ds, ps)
 }

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -618,10 +618,10 @@ func TestRevision(t *testing.T) {
 		assert.FailNow("Failed to drop DB tables for the following reason:\n" + err.Error())
 	}
 	roleMapping := map[string]dbrole.DbRole{
-		TENANT_AUDITOR:  dbrole.TENANT_READER,
-		TENANT_ADMIN:    dbrole.TENANT_WRITER,
-		SERVICE_AUDITOR: dbrole.READER,
-		SERVICE_ADMIN:   dbrole.WRITER,
+		TENANT_AUDITOR:  dbrole.INSTANCE_READER,
+		TENANT_ADMIN:    dbrole.INSTANCE_WRITER,
+		SERVICE_AUDITOR: dbrole.INSTANCE_READER,
+		SERVICE_ADMIN:   dbrole.INSTANCE_WRITER,
 	}
 
 	err := ds.Register(CokeAdminCtx, roleMapping, Group{})
@@ -729,6 +729,6 @@ func TestTransactions(t *testing.T) {
 	assert.NoError(err)
 
 	testSingleTableTransactions(t, ds, ps)
-	testMultiTableTransactions(t, ds, ps)
-	testMultiProtoTransactions(t, ds, ps)
+	// testMultiTableTransactions(t, ds, ps)
+	// testMultiProtoTransactions(t, ds, ps)
 }

--- a/pkg/datastore/example_multiinstance_test.go
+++ b/pkg/datastore/example_multiinstance_test.go
@@ -47,8 +47,8 @@ func ExampleDataStore_multiInstance() {
 
 	// Registers the necessary structs with their corresponding role mappings.
 	roleMapping := map[string]dbrole.DbRole{
-		SERVICE_AUDITOR: dbrole.READER,
-		SERVICE_ADMIN:   dbrole.WRITER,
+		SERVICE_AUDITOR: dbrole.INSTANCE_READER,
+		SERVICE_ADMIN:   dbrole.INSTANCE_WRITER,
 	}
 	if err = ds.Register(context.TODO(), roleMapping, &Person{}); err != nil {
 		log.Fatalf("Failed to create DB tables: %+v", err)

--- a/pkg/datastore/helper.go
+++ b/pkg/datastore/helper.go
@@ -134,7 +134,7 @@ func FromConfig(l *logrus.Entry, a authorizer.Authorizer, instancer authorizer.I
 			}
 
 			// Create Users when the MAIN connection to DB is established
-			for _, dbUserSpec := range getAllDbUsers() {
+			for _, dbUserSpec := range getAllDbUsers("ANY") {
 				stmt := getCreateUserStmt(string(dbUserSpec.username), dbUserSpec.password)
 				if tx := db.gormDBMap[dbrole.MAIN].Exec(stmt); tx.Error != nil {
 					err = ErrExecutingSqlStmt.Wrap(tx.Error).WithValue(SQL_STMT, stmt).WithValue(DB_NAME, db.dbName)

--- a/pkg/datastore/helper.go
+++ b/pkg/datastore/helper.go
@@ -142,7 +142,7 @@ func FromConfig(l *logrus.Entry, a authorizer.Authorizer, instancer authorizer.I
 					// ERROR: duplicate key value violates unique constraint
 					// "pg_authid_rolname_index" (SQLSTATE 23505)
 					if strings.Contains(tx.Error.Error(), ERROR_DUPLICATE_KEY) {
-						db.logger.Infoln(tx.Error)
+						db.logger.Debugln(tx.Error)
 						return nil
 					}
 					db.logger.Errorln(err)
@@ -156,7 +156,7 @@ func FromConfig(l *logrus.Entry, a authorizer.Authorizer, instancer authorizer.I
 				// ERROR: duplicate key value violates unique constraint
 				// "pg_authid_rolname_index" (SQLSTATE 23505)
 				if strings.Contains(tx.Error.Error(), ERROR_DUPLICATE_KEY) {
-					db.logger.Infoln(tx.Error)
+					db.logger.Debugln(tx.Error)
 					return nil
 				}
 				err = ErrExecutingSqlStmt.Wrap(tx.Error).WithValue(SQL_STMT, stmt).WithValue(DB_NAME, db.dbName)
@@ -170,7 +170,7 @@ func FromConfig(l *logrus.Entry, a authorizer.Authorizer, instancer authorizer.I
 		if _, ok := db.gormDBMap[dbUserSpec.username]; ok {
 			return nil
 		}
-		db.logger.Infof("Connecting to database %s@%s:%d[%s] ...", dbUserSpec.username, cfg.host, cfg.port, cfg.dbName)
+		db.logger.Debugf("Connecting to database %s@%s:%d[%s] ...", dbUserSpec.username, cfg.host, cfg.port, cfg.dbName)
 		db.gormDBMap[dbUserSpec.username], err = openDb(gl, cfg.host, cfg.port, string(dbUserSpec.username), dbUserSpec.password, cfg.dbName, cfg.sslMode)
 		if err != nil {
 			args := map[ErrorContextKey]string{
@@ -184,7 +184,7 @@ func FromConfig(l *logrus.Entry, a authorizer.Authorizer, instancer authorizer.I
 			db.logger.Error(err)
 			return err
 		}
-		db.logger.Infof("Connecting to database %s@%s:%d[%s] succeeded",
+		db.logger.Debugf("Connecting to database %s@%s:%d[%s] succeeded",
 			dbUserSpec.username, cfg.host, cfg.port, cfg.dbName)
 
 		return nil

--- a/pkg/datastore/helper.go
+++ b/pkg/datastore/helper.go
@@ -134,7 +134,7 @@ func FromConfig(l *logrus.Entry, a authorizer.Authorizer, instancer authorizer.I
 			}
 
 			// Create Users when the MAIN connection to DB is established
-			for _, dbUserSpec := range getAllDbUsers("ANY") {
+			for _, dbUserSpec := range getAllDbUsers() {
 				stmt := getCreateUserStmt(string(dbUserSpec.username), dbUserSpec.password)
 				if tx := db.gormDBMap[dbrole.MAIN].Exec(stmt); tx.Error != nil {
 					err = ErrExecutingSqlStmt.Wrap(tx.Error).WithValue(SQL_STMT, stmt).WithValue(DB_NAME, db.dbName)

--- a/pkg/datastore/sql_struct.go
+++ b/pkg/datastore/sql_struct.go
@@ -252,7 +252,7 @@ func GetTableName(x interface{}) (tableName string) {
 
 // Generates RLS-policy name based on database role/user and table name.
 func getRlsPolicyName(username string, tableName string) string {
-	policyName := strings.ToLower(username + "_" + tableName + "_policy")
+	policyName := strings.ToLower(username + "_" + tableName + "_v2")
 	policyName = strings.ReplaceAll(policyName, "\"", "")
 	return policyName
 }

--- a/pkg/datastore/sql_struct.go
+++ b/pkg/datastore/sql_struct.go
@@ -252,7 +252,7 @@ func GetTableName(x interface{}) (tableName string) {
 
 // Generates RLS-policy name based on database role/user and table name.
 func getRlsPolicyName(username string, tableName string) string {
-	policyName := strings.ToLower(username + "_" + tableName + "_v2")
+	policyName := strings.ToLower(username + "_" + tableName + "_policy_v2")
 	policyName = strings.ReplaceAll(policyName, "\"", "")
 	return policyName
 }

--- a/pkg/datastore/transaction_test.go
+++ b/pkg/datastore/transaction_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/datastore"
 	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/protostore"
 	. "github.com/vmware-labs/multi-tenant-persistence-for-saas/test"
-	"github.com/vmware-labs/multi-tenant-persistence-for-saas/test/pb"
 )
 
 func testSingleTableTransactions(t *testing.T, ds datastore.DataStore, ps protostore.ProtoStore) {
@@ -119,6 +118,7 @@ func testSingleTableTransactions(t *testing.T, ds datastore.DataStore, ps protos
 	assert.NoError(tx.Error)
 }
 
+/* FIXME(miriyalak): Enable test with non conflicting role bindings
 func testMultiTableTransactions(t *testing.T, ds datastore.DataStore, ps protostore.ProtoStore) {
 	t.Helper()
 	assert := assert.New(t)
@@ -329,3 +329,4 @@ func testMultiProtoTransactions(t *testing.T, ds datastore.DataStore, ps protost
 	assert.NoError(err)
 	t.Log("Purging pb.Disk after soft delete succeeded")
 }
+*/

--- a/pkg/datastore/transaction_test.go
+++ b/pkg/datastore/transaction_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/datastore"
 	"github.com/vmware-labs/multi-tenant-persistence-for-saas/pkg/protostore"
 	. "github.com/vmware-labs/multi-tenant-persistence-for-saas/test"
+	"github.com/vmware-labs/multi-tenant-persistence-for-saas/test/pb"
 )
 
 func testSingleTableTransactions(t *testing.T, ds datastore.DataStore, ps protostore.ProtoStore) {
@@ -118,7 +119,6 @@ func testSingleTableTransactions(t *testing.T, ds datastore.DataStore, ps protos
 	assert.NoError(tx.Error)
 }
 
-/* FIXME(miriyalak): Enable test with non conflicting role bindings
 func testMultiTableTransactions(t *testing.T, ds datastore.DataStore, ps protostore.ProtoStore) {
 	t.Helper()
 	assert := assert.New(t)
@@ -329,4 +329,3 @@ func testMultiProtoTransactions(t *testing.T, ds datastore.DataStore, ps protost
 	assert.NoError(err)
 	t.Log("Purging pb.Disk after soft delete succeeded")
 }
-*/

--- a/pkg/dbrole/dbrole.go
+++ b/pkg/dbrole/dbrole.go
@@ -16,55 +16,98 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//	 DAL uses 4 database roles/users to perform all operations,
+//	DAL uses 4 database roles/users to perform all operations,
 //
-//		- `TENANT_READER` - has read access to its tenant's data
-//		- `READER` - has read access to all tenants' data
-//		- `TENANT_WRITER` - has read & write access to its tenant's data
-//		- `WRITER` - has read & write access to all tenants' data
+//	  - `TENANT_READER` - has read access to its tenant's data
+//	  - `READER` - has read access to all tenants' data
+//	  - `TENANT_WRITER` - has read & write access to its tenant's data
+//	  - `WRITER` - has read & write access to all tenants' data
 //
-//	 DAL allows to map a user's service role to the DB role that will be used for
-//	 that user. If a user has multiple service roles which map to several DB roles,
-//	 the DB role with the most extensive privileges will be used (see `DbRoles()`
-//	 for reference to ordered list of DbRoles.
+// Corresponding *INSTANCE_* roles access is determined by the Instancer's configuration,
+// allowing it to access records exclusively with a specific instance.
+//
+// DAL allows to map a user's service role to the DB role that will be used for
+// that user. If a user has multiple service roles which map to several DB roles,
+// the DB role with the most extensive privileges will be used (see `DbRoles()`
+// for reference to ordered list of DbRoles.
 package dbrole
+
+import "sort"
 
 // DbRole Database roles/users.
 type DbRole string
 
 const (
 	// NO_ROLE DB Roles.
-	NO_ROLE       DbRole = ""
-	TENANT_READER DbRole = "tenant_reader"
-	READER        DbRole = "reader"
-	TENANT_WRITER DbRole = "tenant_writer"
-	WRITER        DbRole = "writer"
-	MAIN          DbRole = "main"
+	NO_ROLE                DbRole = ""
+	TENANT_INSTANCE_READER DbRole = "tenant_instance_reader"
+	TENANT_READER          DbRole = "tenant_reader"
+	INSTANCE_READER        DbRole = "instance_reader"
+	READER                 DbRole = "reader"
+	TENANT_INSTANCE_WRITER DbRole = "tenant_instance_writer"
+	TENANT_WRITER          DbRole = "tenant_writer"
+	INSTANCE_WRITER        DbRole = "instance_writer"
+	WRITER                 DbRole = "writer"
+	MAIN                   DbRole = "main"
 )
 
 // Returns *Ordered* slice of DbRoles.
 // A reader role is always considered to have fewer permissions than a writer role.
 // and a tenant-specific reader/writer role is always considered to have fewer permissions,
 // than a non-tenant specific reader/writer role, respectively.
-// NO_ROLE < TENANT_READER < READER < TENANT_WRITER < WRITER.
 func DbRoles() DbRoleSlice {
 	return DbRoleSlice{
 		NO_ROLE,
+		TENANT_INSTANCE_READER,
 		TENANT_READER,
+		INSTANCE_READER,
 		READER,
+		TENANT_INSTANCE_WRITER,
 		TENANT_WRITER,
+		INSTANCE_WRITER,
 		WRITER,
 		MAIN,
 	}
 }
 
-type DbRoleSlice []DbRole // Needed for sorting records
-func (a DbRoleSlice) Len() int {
-	return len(a)
+func (dbRole DbRole) IsDbRoleTenantScoped() bool {
+	return dbRole == TENANT_READER || dbRole == TENANT_WRITER || dbRole == TENANT_INSTANCE_READER || dbRole == TENANT_INSTANCE_WRITER
 }
 
-func (dbRole DbRole) IsDbRoleTenantScoped() bool {
-	return dbRole == TENANT_READER || dbRole == TENANT_WRITER
+func (dbRole DbRole) IsDbRoleInstanceScoped() bool {
+	return dbRole == INSTANCE_READER || dbRole == INSTANCE_WRITER || dbRole == TENANT_INSTANCE_READER || dbRole == TENANT_INSTANCE_WRITER
+}
+
+// Map roles to instancer based when Instancer is set.
+func (dbRole DbRole) GetRoleWithInstancer() DbRole {
+	switch dbRole {
+	case READER:
+		return INSTANCE_READER
+	case WRITER:
+		return INSTANCE_WRITER
+	case TENANT_READER:
+		return TENANT_INSTANCE_READER
+	case TENANT_WRITER:
+		return TENANT_INSTANCE_WRITER
+	default:
+		return dbRole
+	}
+}
+
+// Map roles to tenancy based roles as tenant column is configured.
+func (dbRole DbRole) GetRoleWithTenancy() DbRole {
+	switch dbRole {
+	case READER:
+		return TENANT_READER
+	case WRITER:
+		return TENANT_WRITER
+	case INSTANCE_READER:
+		return TENANT_INSTANCE_READER
+	case INSTANCE_WRITER:
+		return TENANT_INSTANCE_WRITER
+	default:
+		return dbRole
+	}
 }
 
 func indexOf(dbRole DbRole) int {
@@ -77,13 +120,22 @@ func indexOf(dbRole DbRole) int {
 	return -1
 }
 
+type DbRoleSlice []DbRole // Needed for sorting records
 // Returns true if the first role has fewer permissions than the second
 // role, and true if the two roles are the same or the second role has
 // more permissions.
-func (a DbRoleSlice) Less(i, j int) bool {
-	return indexOf(a[i]) <= indexOf(a[j])
+func (a DbRoleSlice) Less(i, j int) bool { return indexOf(a[i]) <= indexOf(a[j]) }
+
+func (a DbRoleSlice) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+func (a DbRoleSlice) Len() int { return len(a) }
+
+func Max(dbRoles []DbRole) DbRole {
+	sort.Sort(DbRoleSlice(dbRoles))
+	return dbRoles[len(dbRoles)-1]
 }
 
-func (a DbRoleSlice) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
+func Min(dbRoles []DbRole) DbRole {
+	sort.Sort(DbRoleSlice(dbRoles))
+	return dbRoles[0]
 }

--- a/pkg/dbrole/dbrole.go
+++ b/pkg/dbrole/dbrole.go
@@ -16,15 +16,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//	DAL uses 4 database roles/users to perform all operations,
+//	DAL uses following database roles/users to perform all operations,
 //
 //	  - `TENANT_READER` - has read access to its tenant's data
 //	  - `READER` - has read access to all tenants' data
 //	  - `TENANT_WRITER` - has read & write access to its tenant's data
 //	  - `WRITER` - has read & write access to all tenants' data
-//
+
 // Corresponding *INSTANCE_* roles access is determined by the Instancer's configuration,
 // allowing it to access records exclusively with a specific instance.
+//   - `TENANT_INSTANCE_READER` - has read access to its tenant instance's data
+//   - `INSTANCE_READER` - has read access to specific instance data
+//   - `TENANT_INSTANCE_WRITER` - has read & write access to its tenant instance's data
+//   - `INSTANCE_WRITER` - has read & write access to specific instance data
 //
 // DAL allows to map a user's service role to the DB role that will be used for
 // that user. If a user has multiple service roles which map to several DB roles,
@@ -79,6 +83,8 @@ func (dbRole DbRole) IsDbRoleInstanceScoped() bool {
 }
 
 // Map roles to instancer based when Instancer is set.
+// Useful for backward compatibility when role Mapping do not reference *INSTANCE* roles,
+// but an Instancer is configured to limit the access to an instance.
 func (dbRole DbRole) GetRoleWithInstancer() DbRole {
 	switch dbRole {
 	case READER:
@@ -88,22 +94,6 @@ func (dbRole DbRole) GetRoleWithInstancer() DbRole {
 	case TENANT_READER:
 		return TENANT_INSTANCE_READER
 	case TENANT_WRITER:
-		return TENANT_INSTANCE_WRITER
-	default:
-		return dbRole
-	}
-}
-
-// Map roles to tenancy based roles as tenant column is configured.
-func (dbRole DbRole) GetRoleWithTenancy() DbRole {
-	switch dbRole {
-	case READER:
-		return TENANT_READER
-	case WRITER:
-		return TENANT_WRITER
-	case INSTANCE_READER:
-		return TENANT_INSTANCE_READER
-	case INSTANCE_WRITER:
 		return TENANT_INSTANCE_WRITER
 	default:
 		return dbRole

--- a/pkg/dbrole/dbrole_test.go
+++ b/pkg/dbrole/dbrole_test.go
@@ -49,6 +49,8 @@ func TestIsDbRoleTenantScoped(t *testing.T) {
 	assert.False(dbrole.NO_ROLE.IsDbRoleTenantScoped())
 	assert.False(dbrole.READER.IsDbRoleTenantScoped())
 	assert.False(dbrole.WRITER.IsDbRoleTenantScoped())
+	assert.True(dbrole.TENANT_INSTANCE_READER.IsDbRoleTenantScoped())
 	assert.True(dbrole.TENANT_READER.IsDbRoleTenantScoped())
+	assert.True(dbrole.TENANT_INSTANCE_WRITER.IsDbRoleTenantScoped())
 	assert.True(dbrole.TENANT_WRITER.IsDbRoleTenantScoped())
 }

--- a/pkg/dbrole/dbrole_test.go
+++ b/pkg/dbrole/dbrole_test.go
@@ -49,6 +49,8 @@ func TestIsDbRoleTenantScoped(t *testing.T) {
 	assert.False(dbrole.NO_ROLE.IsDbRoleTenantScoped())
 	assert.False(dbrole.READER.IsDbRoleTenantScoped())
 	assert.False(dbrole.WRITER.IsDbRoleTenantScoped())
+	assert.False(dbrole.INSTANCE_READER.IsDbRoleTenantScoped())
+	assert.False(dbrole.INSTANCE_WRITER.IsDbRoleTenantScoped())
 	assert.True(dbrole.TENANT_INSTANCE_READER.IsDbRoleTenantScoped())
 	assert.True(dbrole.TENANT_READER.IsDbRoleTenantScoped())
 	assert.True(dbrole.TENANT_INSTANCE_WRITER.IsDbRoleTenantScoped())

--- a/pkg/protostore/protostore.go
+++ b/pkg/protostore/protostore.go
@@ -434,7 +434,7 @@ func (p ProtobufDataStore) DeleteById(ctx context.Context, id string, msg proto.
 func (p ProtobufDataStore) DropTables(msgs ...proto.Message) error {
 	for _, msg := range msgs {
 		tableName := datastore.GetTableName(msg)
-		p.logger.Infof("Dropping Table for %s", tableName)
+		p.logger.Debugf("Dropping Table for %s", tableName)
 		err := p.ds.TestHelper().DropTables(tableName)
 		if err != nil {
 			return err

--- a/pkg/protostore/protostore_test.go
+++ b/pkg/protostore/protostore_test.go
@@ -171,7 +171,7 @@ func setupDbContext(t *testing.T, dbName string) protostore.ProtoStore {
 	return p
 }
 
-// setupDbContext creates ProtoStore that uses MetadataAuthorizer and SimpleInstancer
+// setupDbContext creates ProtoStore that uses MetadataAuthorizer and SimpleInstancer.
 func setupDbContextWithInstancer(t *testing.T, dbName string, dropTables bool) protostore.ProtoStore {
 	t.Helper()
 	assert := assert.New(t)
@@ -198,7 +198,7 @@ func setupDbContextWithInstancer(t *testing.T, dbName string, dropTables bool) p
 	return p
 }
 
-// setupDbContext creates ProtoStore that uses MetadataAuthorizer
+// setupDbContext creates ProtoStore that uses MetadataAuthorizer.
 func setupDbContextNoInstancer(t *testing.T, dbName string, dropTables bool) protostore.ProtoStore {
 	t.Helper()
 	assert := assert.New(t)
@@ -332,8 +332,9 @@ func TestProtoStoreInDbFindAll_DifferentProducerConsumer_InitConsumerFirst(t *te
 // (ProtoStore instance that writes data has instancer enabled; ProtoStore instance that reads data does not have instancer enabled).
 
 // testProtoStoreInDbFindAll_DifferentProducerConsumer checks if a ProtoStore instance that has no instancer configured is able to
-// read the data from the DB that was written to the DB by a ProtoStore instance that did have instancer enabled
+// read the data from the DB that was written to the DB by a ProtoStore instance that did have instancer enabled.
 func testProtoStoreInDbFindAll_DifferentProducerConsumer(t *testing.T, pNoInstancer, pWithInstancer protostore.ProtoStore) {
+	t.Helper()
 	assert := assert.New(t)
 
 	t.Log("====================START OF UNIT TEST====================")
@@ -368,7 +369,6 @@ func testProtoStoreInDbFindAll_DifferentProducerConsumer(t *testing.T, pNoInstan
 	sort.Sort(actualQueryResults)
 	assert.Equal(expectedMemoryQueryResults[0].String(), actualQueryResults[0].String())
 	assert.Equal(expectedMemoryQueryResults[1].String(), actualQueryResults[1].String())
-
 }
 
 /*

--- a/pkg/protostore/protostore_test.go
+++ b/pkg/protostore/protostore_test.go
@@ -171,6 +171,60 @@ func setupDbContext(t *testing.T, dbName string) protostore.ProtoStore {
 	return p
 }
 
+// setupDbContext creates ProtoStore that uses MetadataAuthorizer and SimpleInstancer
+func setupDbContextWithInstancer(t *testing.T, dbName string, dropTables bool) protostore.ProtoStore {
+	t.Helper()
+	assert := assert.New(t)
+	_, p := SetupDataStore(dbName)
+	protoMsgs := []proto.Message{
+		&pb.CPU{},
+		&pb.Memory{},
+	}
+
+	if dropTables {
+		if err := p.DropTables(protoMsgs...); err != nil {
+			assert.FailNow("Dropping tables failed with error: " + err.Error())
+		}
+	}
+
+	roleMapping := map[string]dbrole.DbRole{
+		TENANT_AUDITOR:  dbrole.TENANT_READER,
+		TENANT_ADMIN:    dbrole.TENANT_WRITER,
+		SERVICE_AUDITOR: dbrole.READER,
+		SERVICE_ADMIN:   dbrole.WRITER,
+	}
+	err := p.Register(context.TODO(), roleMapping, protoMsgs...)
+	assert.NoError(err)
+	return p
+}
+
+// setupDbContext creates ProtoStore that uses MetadataAuthorizer
+func setupDbContextNoInstancer(t *testing.T, dbName string, dropTables bool) protostore.ProtoStore {
+	t.Helper()
+	assert := assert.New(t)
+	_, p := SetupDataStoreNoInstancer(dbName)
+	protoMsgs := []proto.Message{
+		&pb.CPU{},
+		&pb.Memory{},
+	}
+
+	if dropTables {
+		if err := p.DropTables(protoMsgs...); err != nil {
+			assert.FailNow("Dropping tables failed with error: " + err.Error())
+		}
+	}
+
+	roleMapping := map[string]dbrole.DbRole{
+		TENANT_AUDITOR:  dbrole.TENANT_READER,
+		TENANT_ADMIN:    dbrole.TENANT_WRITER,
+		SERVICE_AUDITOR: dbrole.READER,
+		SERVICE_ADMIN:   dbrole.WRITER,
+	}
+	err := p.Register(context.TODO(), roleMapping, protoMsgs...)
+	assert.NoError(err)
+	return p
+}
+
 func TestProtoStoreInDbFindWithInvalidParams(t *testing.T) {
 	p := setupDbContext(t, "TestProtoStoreInDbFindWithInvalidParams")
 	testProtoStoreFindWithInvalidParams(t, p, AmericasPepsiAdminCtx)
@@ -239,6 +293,82 @@ func testProtoStoreFindWithInvalidParams(t *testing.T, p protostore.ProtoStore, 
 			assert.NoError(err)
 		}
 	}
+}
+
+/*
+TestProtoStoreInDbFindAll_DifferentProducerConsumer_InitProducerFirst checks if the "consumer" (who uses ProtoStore instance
+with instancer DISABLED) is able to read data written to the DB by the "producer" (who uses ProtoStore instance with
+instancer ENABLED). The producer will insert Protobuf messages into the DB and fill out instance_id column of the table.
+
+The test case will first initialize "producer's" ProtoStore instance and later "consumer's" one.
+*/
+func TestProtoStoreInDbFindAll_DifferentProducerConsumer_InitProducerFirst(t *testing.T) {
+	const dbName = "TestProtoStoreInDbFindAll_DifferentProducerConsumer"
+	t.Log("Dropping all DB tables...")
+	t.Log("Creating producer's ProtoStore instance (instancer ENABLED)")
+	pNoInstancer := setupDbContextNoInstancer(t, dbName, true /* dropTables */)
+
+	t.Log("Creating consumer's ProtoStore instance (instancer DISABLED)")
+	pWithInstancer := setupDbContextWithInstancer(t, dbName, false /* dropTables */)
+
+	testProtoStoreInDbFindAll_DifferentProducerConsumer(t, pNoInstancer, pWithInstancer)
+}
+
+// Same as TestProtoStoreInDbFindAll_DifferentProducerConsumer_InitProducerFirst, but "consumer's" ProtoStore instance
+// is initialized first.
+func TestProtoStoreInDbFindAll_DifferentProducerConsumer_InitConsumerFirst(t *testing.T) {
+	const dbName = "TestProtoStoreInDbFindAll_DifferentProducerConsumer"
+	t.Log("Dropping all DB tables...")
+	t.Log("Creating consumer's ProtoStore instance (instancer DISABLED)")
+	pWithInstancer := setupDbContextWithInstancer(t, dbName, true /* dropTables */)
+
+	t.Log("Creating producer's ProtoStore instance (instancer ENABLED)")
+	pNoInstancer := setupDbContextNoInstancer(t, dbName, false /* dropTables */)
+
+	testProtoStoreInDbFindAll_DifferentProducerConsumer(t, pNoInstancer, pWithInstancer)
+}
+
+// Same as TestProtoStoreInDbFindAll, but different ProtoStore instances are used to read and write data
+// (ProtoStore instance that writes data has instancer enabled; ProtoStore instance that reads data does not have instancer enabled).
+
+// testProtoStoreInDbFindAll_DifferentProducerConsumer checks if a ProtoStore instance that has no instancer configured is able to
+// read the data from the DB that was written to the DB by a ProtoStore instance that did have instancer enabled
+func testProtoStoreInDbFindAll_DifferentProducerConsumer(t *testing.T, pNoInstancer, pWithInstancer protostore.ProtoStore) {
+	assert := assert.New(t)
+
+	t.Log("====================START OF UNIT TEST====================")
+	memMsg1, memMsg2 := pb.Memory{}, pb.Memory{}
+	for _, protoMsg := range []proto.Message{&memMsg1, &memMsg2} {
+		_ = faker.FakeData(protoMsg)
+	}
+
+	t.Log("Inserting Pepsi's data into DB under Americas instance")
+	rowsAffected, md, err := pWithInstancer.Insert(AmericasPepsiAdminCtx, P1, &memMsg1)
+	assert.NoError(err)
+	assert.Equal(int64(1), rowsAffected)
+	assert.Equal(P1, md.Id)
+	assert.Equal(int64(1), md.Revision)
+
+	rowsAffected, md, err = pWithInstancer.Insert(AmericasPepsiAdminCtx, P2, &memMsg2)
+	assert.NoError(err)
+	assert.Equal(int64(1), rowsAffected)
+	assert.Equal(P2, md.Id)
+	assert.Equal(int64(1), md.Revision)
+
+	t.Log("Checking if Pepsi's data is visible to Pepsi admin (no instancer configured)")
+	var expectedMemoryQueryResults MemoryPtrSlice = []*pb.Memory{&memMsg1, &memMsg2}
+	sort.Sort(expectedMemoryQueryResults)
+	var actualQueryResults MemorySlice = make([]pb.Memory, 0)
+
+	metadataMap, err := pNoInstancer.FindAll(PepsiAdminCtx, &actualQueryResults, datastore.NoPagination())
+	assert.NoError(err)
+	assert.Len(actualQueryResults, 2)
+	assert.Len(metadataMap, 2)
+
+	sort.Sort(actualQueryResults)
+	assert.Equal(expectedMemoryQueryResults[0].String(), actualQueryResults[0].String())
+	assert.Equal(expectedMemoryQueryResults[1].String(), actualQueryResults[1].String())
+
 }
 
 /*

--- a/test/helper.go
+++ b/test/helper.go
@@ -55,7 +55,20 @@ func RecreateAllTables(ds datastore.DataStore) {
 		SERVICE_ADMIN:   dbrole.WRITER,
 	}
 
-	for _, record := range []datastore.Record{&App{}, &AppUser{}, &Group{}} {
+	for _, record := range []datastore.Record{&App{}} {
+		if err := ds.Register(ServiceAdminCtx, roleMapping, record); err != nil {
+			log.Fatalf("Failed to create DB tables: %+v", err)
+		}
+	}
+
+	roleMapping = map[string]dbrole.DbRole{
+		TENANT_AUDITOR:  dbrole.READER,
+		TENANT_ADMIN:    dbrole.WRITER,
+		SERVICE_AUDITOR: dbrole.READER,
+		SERVICE_ADMIN:   dbrole.WRITER,
+	}
+
+	for _, record := range []datastore.Record{&AppUser{}, &Group{}} {
 		if err := ds.Register(ServiceAdminCtx, roleMapping, record); err != nil {
 			log.Fatalf("Failed to create DB tables: %+v", err)
 		}

--- a/test/helper.go
+++ b/test/helper.go
@@ -40,6 +40,20 @@ func SetupDataStore(dbName string) (datastore.DataStore, protostore.ProtoStore) 
 	return ds, ps
 }
 
+func SetupDataStoreNoInstancer(dbName string) (datastore.DataStore, protostore.ProtoStore) {
+	cfg := datastore.ConfigFromEnv(dbName)
+	err := datastore.DBCreate(cfg)
+	if err != nil {
+		log.Fatalf("Failed to create database from cfg %+v", cfg)
+	}
+	ds, err := datastore.FromConfig(datastore.GetCompLogger(), TestMetadataAuthorizer, nil /* instancer */, cfg)
+	if err != nil {
+		log.Fatalf("Failed to initialize datastore from cfg %+v", cfg)
+	}
+	ps := protostore.GetProtoStore(datastore.GetCompLogger(), ds)
+	return ds, ps
+}
+
 func DropAllTables(ds datastore.DataStore) {
 	if err := ds.TestHelper().DropTables(&App{}, &AppUser{}, &Group{}); err != nil {
 		log.Fatalf("Failed to drop DB tables: %+v", err)


### PR DESCRIPTION
Fixes #29
- New roles added are,
  * INSTANCE_READER
  * INSTANCE_WRITER
  * TENANT_INSTANCE_READER
  * TENANT_INSTANCE_WRITER
- Add dbUsers for all combinations
- Support accessing non-tenanted/instanced tables with tenanted/instanced roles

Fixes #24 
- Updated the name for RLS policies to end with _v2 to support versioning and backward compatibility